### PR TITLE
Market Api client update

### DIFF
--- a/src/market.rs
+++ b/src/market.rs
@@ -8,9 +8,9 @@ pub use requestor::MarketRequestorApi;
 pub(crate) const MARKET_URL_ENV_VAR: &str = "YAGNA_MARKET_URL";
 /// Centralized (Mk1 aka TestBed) Market API instance.
 // TODO: remove it after implementing P2P Market
-const DEFAULT_MARKET_URL: &str = "http://34.244.4.185:8080/market-api/v1/";
+pub const DEFAULT_MARKET_URL: &str = "http://34.244.4.185:8080/market-api/v1/";
 
-fn service_url() -> crate::Result<url::Url> {
+pub fn service_url() -> crate::Result<url::Url> {
     Ok(std::env::var(MARKET_URL_ENV_VAR)
         .unwrap_or(DEFAULT_MARKET_URL.into())
         .parse()?)

--- a/src/market/provider.rs
+++ b/src/market/provider.rs
@@ -7,6 +7,7 @@ use ya_client_model::market::{Agreement, Offer, Proposal, ProviderEvent, MARKET_
 use crate::{web::default_on_timeout, web::WebClient, web::WebInterface, Result};
 
 /// Bindings for Provider part of the Market API.
+#[derive(Clone)]
 pub struct MarketProviderApi {
     client: WebClient,
 }

--- a/src/web.rs
+++ b/src/web.rs
@@ -182,7 +182,6 @@ pub(crate) fn default_on_timeout<T: Default>(err: Error) -> Result<T> {
 #[derive(Clone, Debug)]
 pub struct WebClientBuilder {
     pub(crate) host_port: Option<String>,
-    pub(crate) api_root: Option<String>,
     pub(crate) auth: Option<WebAuth>,
     pub(crate) headers: HeaderMap,
     pub(crate) timeout: Option<Duration>,
@@ -196,11 +195,6 @@ impl WebClientBuilder {
 
     pub fn host_port<T: Into<String>>(mut self, host_port: T) -> Self {
         self.host_port = Some(host_port.into());
-        self
-    }
-
-    pub fn api_root<T: Into<String>>(mut self, api_root: T) -> Self {
-        self.api_root = Some(api_root.into());
         self
     }
 
@@ -255,7 +249,6 @@ impl Default for WebClientBuilder {
     fn default() -> Self {
         WebClientBuilder {
             host_port: None,
-            api_root: None,
             auth: None,
             headers: HeaderMap::new(),
             timeout: None,


### PR DESCRIPTION
This facilitates Market API forwarding: https://github.com/golemfactory/yagna/pull/257
- making central service Url public
- making MarketProviderApi clonable (as all other api parts)

Additionally removes some unused field in `WebClientBuilder`.