### PR TITLE
ExeScriptCommand::Terminate and State::Unresponsive

### DIFF
--- a/model/src/activity/activity_state.rs
+++ b/model/src/activity/activity_state.rs
@@ -83,8 +83,8 @@ pub enum State {
     Initialized,
     Deployed,
     Ready,
-    Active,
     Terminated,
+    Unresponsive,
 }
 
 impl Default for State {

--- a/model/src/activity/exe_script_command.rs
+++ b/model/src/activity/exe_script_command.rs
@@ -28,6 +28,7 @@ pub enum ExeScriptCommand {
         from: String,
         to: String,
     },
+    Terminate {},
 }
 
 impl From<ExeScriptCommand> for ExeScriptCommandState {
@@ -59,6 +60,11 @@ impl From<ExeScriptCommand> for ExeScriptCommandState {
                 progress: None,
                 params: Some(vec![from, to]),
             },
+            ExeScriptCommand::Terminate {} => ExeScriptCommandState {
+                command: "Terminate".to_string(),
+                progress: None,
+                params: None,
+            }
         }
     }
 }

--- a/specs/activity-api.yaml
+++ b/specs/activity-api.yaml
@@ -445,16 +445,19 @@ components:
       type: object
       properties:
         state:
-          type: string
-          enum:
-            - New
-            - Initialized
-            - Deploying
-            - Ready
-            - Starting
-            - Active
-            - Unresponsive
-            - Terminated
+          type: array
+          description: State pair tuple (CurrentState, NextState). NextState is equal to null
+            if there is no pending transition between states.
+          items:
+            type: string
+            nullable: true
+            enum:
+              - New
+              - Initialized
+              - Deployed
+              - Ready
+              - Unresponsive
+              - Terminated
         reason:
           type: string
           description: Reason for Activity termination (specified when Activity in


### PR DESCRIPTION
- added `ExeScriptCommand::Terminate` for terminating the currently executed script
- removed `State::Active` since it's no longer a valid Activity state
- added `State::Unresponsive` for future use

Updated the Activity OpenAPI spec to reflect recent code changes