### PR TITLE
Payment relationships changed

### DIFF
--- a/model/src/payment.rs
+++ b/model/src/payment.rs
@@ -1,4 +1,6 @@
 pub mod acceptance;
+pub mod activity_payment;
+pub mod agreement_payment;
 pub mod allocation;
 pub mod debit_note;
 pub mod debit_note_event;
@@ -11,6 +13,8 @@ pub mod rejection;
 pub mod rejection_reason;
 
 pub use self::acceptance::Acceptance;
+pub use self::activity_payment::ActivityPayment;
+pub use self::agreement_payment::AgreementPayment;
 pub use self::allocation::Allocation;
 pub use self::allocation::NewAllocation;
 pub use self::debit_note::DebitNote;

--- a/model/src/payment/activity_payment.rs
+++ b/model/src/payment/activity_payment.rs
@@ -1,0 +1,9 @@
+use bigdecimal::BigDecimal;
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ActivityPayment {
+    pub activity_id: String,
+    pub amount: BigDecimal,
+}

--- a/model/src/payment/agreement_payment.rs
+++ b/model/src/payment/agreement_payment.rs
@@ -1,0 +1,9 @@
+use bigdecimal::BigDecimal;
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AgreementPayment {
+    pub agreement_id: String,
+    pub amount: BigDecimal,
+}

--- a/model/src/payment/document_status.rs
+++ b/model/src/payment/document_status.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 use std::convert::TryFrom;
+use std::fmt::{Display, Formatter, Result as FmtResult};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "UPPERCASE")]
@@ -40,11 +41,12 @@ impl From<DocumentStatus> for String {
     }
 }
 
-impl ToString for DocumentStatus {
-    fn to_string(&self) -> String {
-        serde_json::to_string(self)
+impl Display for DocumentStatus {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        let str = serde_json::to_string(self)
             .unwrap()
             .trim_matches('"')
-            .to_owned()
+            .to_owned();
+        write!(f, "{}", str)
     }
 }

--- a/model/src/payment/event_type.rs
+++ b/model/src/payment/event_type.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 use std::convert::TryFrom;
+use std::fmt::{Display, Formatter, Result as FmtResult};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "UPPERCASE")]
@@ -32,9 +33,16 @@ impl TryFrom<String> for EventType {
 
 impl From<EventType> for String {
     fn from(event_type: EventType) -> Self {
-        serde_json::to_string(&event_type)
+        event_type.to_string()
+    }
+}
+
+impl Display for EventType {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        let str = serde_json::to_string(self)
             .unwrap()
             .trim_matches('"')
-            .to_owned()
+            .to_owned();
+        write!(f, "{}", str)
     }
 }

--- a/model/src/payment/payment.rs
+++ b/model/src/payment/payment.rs
@@ -1,3 +1,4 @@
+use crate::payment::{ActivityPayment, AgreementPayment};
 use crate::NodeId;
 use bigdecimal::BigDecimal;
 use chrono::{DateTime, Utc};
@@ -13,12 +14,9 @@ pub struct Payment {
     pub payee_addr: String,
     pub amount: BigDecimal,
     pub timestamp: DateTime<Utc>,
-    pub agreement_id: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub allocation_id: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
-    pub debit_note_ids: Option<Vec<String>>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
-    pub invoice_ids: Option<Vec<String>>,
+    pub agreement_payments: Vec<AgreementPayment>,
+    pub activity_payments: Vec<ActivityPayment>,
     pub details: String,
 }

--- a/specs/payment-api.yaml
+++ b/specs/payment-api.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.2
 info:
   title: Yagna Payment API
-  version: 1.1.0
+  version: 1.2.0
   description: '
     Invoicing and Payments is a fundamental area of Yagna Ecosystem
     functionality. It includes aspects of communication between Requestor,
@@ -1282,18 +1282,16 @@ components:
         timestamp:
           type: string
           format: date-time
-        agreementId:
-          type: string
         allocationId:
           type: string
-        debitNoteIds:
+        agreementPayments:
           type: array
           items:
-            type: string
-        invoiceIds:
+            $ref: '#/components/schemas/AgreementPayment'
+        activityPayments:
           type: array
           items:
-            type: string
+            $ref: '#/components/schemas/ActivityPayment'
         details:
           type: string
           format: byte
@@ -1303,8 +1301,38 @@ components:
         - payeeId
         - amount
         - timestamp
-        - agreementId
+        - agreementPayments
+        - activityPayments
         - details
+
+    AgreementPayment:
+      description: >
+        Share of a Payment assigned to an Agreement, but not to any particular
+        Activity within that Agreement.
+      type: object
+      readOnly: true
+      properties:
+        agreementId:
+          type: string
+        amount:
+          type: string
+      required:
+        - agreementId
+        - amount
+
+    ActivityPayment:
+      description: >
+        Share of a Payment assigned to a particular Activity.
+      type: object
+      readOnly: true
+      properties:
+        activityId:
+          type: string
+        amount:
+          type: string
+      required:
+        - activityId
+        - amount
 
     DebitNoteEvent:
       type: object

--- a/src/payment/provider.rs
+++ b/src/payment/provider.rs
@@ -88,7 +88,7 @@ impl PaymentProviderApi {
 
     #[allow(non_snake_case)]
     #[rustfmt::skip]
-    pub async fn cancel_debit_note(&self, debit_note_id: &str) -> Result<String> {
+    pub async fn cancel_debit_note(&self, debit_note_id: &str) -> Result<()> {
         let timeout = self.config.cancel_debit_note_timeout;
         let url = url_format!(
             "provider/debitNotes/{debit_note_id}/cancel",
@@ -155,7 +155,7 @@ impl PaymentProviderApi {
 
     #[allow(non_snake_case)]
     #[rustfmt::skip]
-    pub async fn cancel_invoice(&self, invoice_id: &str) -> Result<String> {
+    pub async fn cancel_invoice(&self, invoice_id: &str) -> Result<()> {
         let timeout = self.config.cancel_invoice_timeout;
         let url = url_format!(
             "provider/invoices/{invoice_id}/cancel",

--- a/src/payment/requestor.rs
+++ b/src/payment/requestor.rs
@@ -72,7 +72,7 @@ impl PaymentRequestorApi {
         &self,
         debit_note_id: &str,
         acceptance: &Acceptance,
-    ) -> Result<String> {
+    ) -> Result<()> {
         let timeout = self.config.accept_debit_note_timeout;
         let url = url_format!(
             "requestor/debitNotes/{debit_note_id}/accept",
@@ -88,7 +88,7 @@ impl PaymentRequestorApi {
         &self,
         debit_note_id: &str,
         rejection: &Rejection,
-    ) -> Result<String> {
+    ) -> Result<()> {
         let timeout = self.config.reject_debit_note_timeout;
         let url = url_format!(
             "requestor/debitNotes/{debit_note_id}/reject",
@@ -151,7 +151,7 @@ impl PaymentRequestorApi {
 
     #[allow(non_snake_case)]
     #[rustfmt::skip]
-    pub async fn reject_invoice(&self, invoice_id: &str, rejection: &Rejection) -> Result<String> {
+    pub async fn reject_invoice(&self, invoice_id: &str, rejection: &Rejection) -> Result<()> {
         let timeout = self.config.reject_invoice_timeout;
         let url = url_format!(
             "requestor/invoices/{invoice_id}/reject",


### PR DESCRIPTION
Direct relationship with invoices and/or debit notes has been abandoned in favour of `AgreementPayment` and `ActivityPayment`. This still allows to establish which particular invoice and/or debit notes have been covered by a payment. On the other hand, this model is more flexible (e.g. allows making partial payments) and makes payment verification easier.

Fixed return types of payment commands 