### PR TITLE
Add debug logging to WebRequest.json

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -34,6 +34,8 @@ pub enum Error {
     InvalidHeaderValue(#[from] awc::http::header::InvalidHeaderValue),
     #[error("invalid UTF8 string: {0}")]
     FromUtf8Error(#[from] std::string::FromUtf8Error),
+    #[error("invalid UTF8 string: {0}")]
+    Utf8Error(#[from] std::str::Utf8Error),
     #[error("Url parse error: {0}")]
     UrlParseError(#[from] url::ParseError),
     #[error("Yagna model error: {0}")]

--- a/src/web.rs
+++ b/src/web.rs
@@ -169,10 +169,10 @@ impl WebRequest<SendClientRequest> {
             ))?);
         }
         let raw_body = response.body().await?;
-        let body = std::str::from_utf8(&raw_body).unwrap();
+        let body = String::from_utf8(raw_body.to_vec())?;
         log::debug!("WebRequest.json(). url={}, resp={}", self.url, body);
 
-        Ok(serde_json::from_str(body)?)
+        Ok(serde_json::from_str(&body)?)
     }
 }
 

--- a/src/web.rs
+++ b/src/web.rs
@@ -168,8 +168,11 @@ impl WebRequest<SendClientRequest> {
                 response.status()
             ))?);
         }
+        let raw_body = response.body().await?;
+        let body = std::str::from_utf8(&raw_body).unwrap();
+        log::debug!("WebRequest.json(). url={}, resp={}", self.url, body);
 
-        Ok(response.json().await?)
+        Ok(serde_json::from_str(body)?)
     }
 }
 

--- a/src/web.rs
+++ b/src/web.rs
@@ -169,10 +169,10 @@ impl WebRequest<SendClientRequest> {
             ))?);
         }
         let raw_body = response.body().await?;
-        let body = String::from_utf8(raw_body.to_vec())?;
+        let body = std::str::from_utf8(&raw_body)?;
         log::debug!("WebRequest.json(). url={}, resp={}", self.url, body);
 
-        Ok(serde_json::from_str(&body)?)
+        Ok(serde_json::from_str(body)?)
     }
 }
 


### PR DESCRIPTION
```
[2020-07-02T15:39:32Z ERROR ya_requestor::activity] processing activity for agreement af67c5b4-a93d-4ed0-b1f5-9376c14973f0 failed: AWC JSON payload error: Error that occur during reading payload: A payload reached size limit.
```

Was getting this error when running the yagna core [demo scenario](https://github.com/golemfactory/yagna-integration/tree/master/test/level0/unix).

Added printing of the response body before converting it to JSON, to help debugging JSON errors like above.