### PR TITLE
Payment API: multi-driver preparations

### DIFF
--- a/model/src/payment/activity_payment.rs
+++ b/model/src/payment/activity_payment.rs
@@ -6,4 +6,6 @@ use serde::{Deserialize, Serialize};
 pub struct ActivityPayment {
     pub activity_id: String,
     pub amount: BigDecimal,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub allocation_id: Option<String>,
 }

--- a/model/src/payment/agreement_payment.rs
+++ b/model/src/payment/agreement_payment.rs
@@ -6,4 +6,6 @@ use serde::{Deserialize, Serialize};
 pub struct AgreementPayment {
     pub agreement_id: String,
     pub amount: BigDecimal,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub allocation_id: Option<String>,
 }

--- a/model/src/payment/allocation.rs
+++ b/model/src/payment/allocation.rs
@@ -6,6 +6,8 @@ use serde::{Deserialize, Serialize};
 #[serde(rename_all = "camelCase")]
 pub struct Allocation {
     pub allocation_id: String,
+    pub address: String,
+    pub payment_platform: String,
     pub total_amount: BigDecimal,
     pub spent_amount: BigDecimal,
     pub remaining_amount: BigDecimal,
@@ -17,6 +19,8 @@ pub struct Allocation {
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct NewAllocation {
+    pub address: Option<String>,
+    pub payment_platform: Option<String>,
     pub total_amount: BigDecimal,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub timeout: Option<DateTime<Utc>>,

--- a/model/src/payment/debit_note.rs
+++ b/model/src/payment/debit_note.rs
@@ -11,6 +11,7 @@ pub struct DebitNote {
     pub recipient_id: NodeId,
     pub payee_addr: String,
     pub payer_addr: String,
+    pub payment_platform: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub previous_debit_note_id: Option<String>,
     pub timestamp: DateTime<Utc>,

--- a/model/src/payment/invoice.rs
+++ b/model/src/payment/invoice.rs
@@ -11,6 +11,7 @@ pub struct Invoice {
     pub recipient_id: NodeId,
     pub payee_addr: String,
     pub payer_addr: String,
+    pub payment_platform: String,
     pub timestamp: DateTime<Utc>,
     pub agreement_id: String,
     pub activity_ids: Vec<String>,

--- a/model/src/payment/payment.rs
+++ b/model/src/payment/payment.rs
@@ -12,6 +12,7 @@ pub struct Payment {
     pub payee_id: NodeId,
     pub payer_addr: String,
     pub payee_addr: String,
+    pub payment_platform: String,
     pub amount: BigDecimal,
     pub timestamp: DateTime<Utc>,
     #[serde(skip_serializing_if = "Option::is_none", default)]

--- a/model/src/payment/payment.rs
+++ b/model/src/payment/payment.rs
@@ -15,8 +15,6 @@ pub struct Payment {
     pub payment_platform: String,
     pub amount: BigDecimal,
     pub timestamp: DateTime<Utc>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
-    pub allocation_id: Option<String>,
     pub agreement_payments: Vec<AgreementPayment>,
     pub activity_payments: Vec<ActivityPayment>,
     pub details: String,

--- a/specs/payment-api.yaml
+++ b/specs/payment-api.yaml
@@ -1076,6 +1076,9 @@ components:
         payerAddr:
           type: string
           readOnly: true
+        paymentPlatform:
+          type: string
+          readOnly: true
         previousDebitNoteId:
           type: string
           readOnly: true
@@ -1136,6 +1139,9 @@ components:
           type: string
           readOnly: true
         payerAddr:
+          type: string
+          readOnly: true
+        paymentPlatform:
           type: string
           readOnly: true
         lastDebitNoteId:
@@ -1242,6 +1248,10 @@ components:
         allocationId:
           type: string
           readOnly: true
+        address:
+          type: string
+        paymentPlatform:
+          type: string
         totalAmount:
           type: string
         spentAmount:
@@ -1277,6 +1287,8 @@ components:
           type: string
         payeeAddr:
           type: string
+        paymentPlatform:
+          type: string
         amount:
           type: string
         timestamp:
@@ -1299,6 +1311,9 @@ components:
         - paymentId
         - payerId
         - payeeId
+        - payerAddr
+        - payeeAddr
+        - paymentPlatform
         - amount
         - timestamp
         - agreementPayments

--- a/specs/payment-api.yaml
+++ b/specs/payment-api.yaml
@@ -1294,8 +1294,6 @@ components:
         timestamp:
           type: string
           format: date-time
-        allocationId:
-          type: string
         agreementPayments:
           type: array
           items:
@@ -1331,6 +1329,8 @@ components:
           type: string
         amount:
           type: string
+        allocationId:
+          type: string
       required:
         - agreementId
         - amount
@@ -1344,6 +1344,8 @@ components:
         activityId:
           type: string
         amount:
+          type: string
+        allocationId:
           type: string
       required:
         - activityId


### PR DESCRIPTION
### Re-introduced `payment_platform`

This field will be needed for supporting multiple payment platforms in the payment API. For debit notes, invoices, and payments it is a read-only field. For allocations it can provided during creation but isn't required (will be filled in with default values).

### `allocation_id` moved

Payment object represents a single (blockchain) transaction. It is possible that it includes activity payments and/or agreement payments from multiple users (but using the same wallet). Therefore, it can be also spending from multiple allocations. To adequately represent this situation `allocation_id` has been removed from `Payment` and added to `ActivityPayment` and `AgreementPayment`.