### PR TITLE
SGX: use hex encoding, extended models, session key verification

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 [features]
 default = []
 cli = ['structopt']
-sgx=['secp256k1', 'openssl', 'secp256k1/serde', 'secp256k1/rand', 'ya-client-model/sgx']
+sgx = ['secp256k1', 'openssl', 'secp256k1/serde', 'secp256k1/rand', 'ya-client-model/sgx']
 
 [workspace]
 members = [
@@ -29,16 +29,15 @@ envy = "0.4"
 failure = "0.1.6"
 futures = "0.3"
 log = "0.4"
+rand = "0.6"
 serde = "1.0"
 serde_json = "1.0"
-structopt = { version = "0.3.12", optional = true }
 thiserror = "1.0"
 url = "2.1"
 
-secp256k1={ version = "0.17.2", optional=true }
-openssl= { version="0.10", optional=true }
-base64 = { version = "0.12.3", optional = true}
-rand = "0.6"
+secp256k1 = { version = "0.17.2", optional = true }
+structopt = { version = "0.3.12", optional = true }
+openssl = { version = "0.10", optional = true }
 
 [dev-dependencies]
 actix-rt = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 [features]
 default = []
 cli = ['structopt']
-sgx = ['secp256k1', 'openssl', 'secp256k1/serde', 'secp256k1/rand', 'ya-client-model/sgx']
+sgx = ['openssl', 'secp256k1/serde', 'secp256k1/rand', 'sha3', 'ya-client-model/sgx']
 
 [workspace]
 members = [
@@ -36,6 +36,7 @@ thiserror = "1.0"
 url = "2.1"
 
 secp256k1 = { version = "0.17.2", optional = true }
+sha3 = { version = "0.8", optional = true }
 structopt = { version = "0.3.12", optional = true }
 openssl = { version = "0.10", optional = true }
 

--- a/model/Cargo.toml
+++ b/model/Cargo.toml
@@ -11,17 +11,17 @@ edition = "2018"
 [features]
 default = []
 with-diesel = ['diesel']
-sgx=['secp256k1', 'openssl', 'base64', 'secp256k1/serde']
+sgx = ['secp256k1', 'openssl', 'hex', 'secp256k1/serde']
 
 [dependencies]
 bigdecimal = { version = "0.1.0", features = ["serde"]}
 chrono = { version = "0.4", features = ["serde"]}
-diesel = { version = "1.4", optional = true }
+rand = "0.7.3"
 serde = { version = "^1.0", features = ["derive"] }
 serde_json = "^1.0"
 thiserror = "1.0"
 
-secp256k1={ version = "0.17", optional=true }
-openssl= { version="0.10", optional=true }
-base64 = { version = "0.12.3", optional = true}
-rand = "0.7.3"
+diesel = { version = "1.4", optional = true }
+hex = { version = "0.4", optional = true}
+secp256k1 = { version = "0.17", optional = true }
+openssl = { version = "0.10", optional = true }

--- a/model/src/activity/encrypted.rs
+++ b/model/src/activity/encrypted.rs
@@ -1,4 +1,4 @@
-use crate::activity::{ExeScriptCommand, ExeScriptCommandResult};
+use crate::activity::{ExeScriptCommand, ExeScriptCommandResult, ExeScriptCommandState};
 use rand::Rng as _;
 use secp256k1::ecdh::SharedSecret;
 use secp256k1::{PublicKey, SecretKey};
@@ -19,6 +19,7 @@ pub struct Request {
 pub enum RequestCommand {
     Exec { exe_script: Vec<ExeScriptCommand> },
     GetExecBatchResults { command_index: Option<usize> },
+    GetRunningCommand,
 }
 
 #[derive(Clone, Serialize, Deserialize)]
@@ -27,6 +28,7 @@ pub enum RequestCommand {
 pub enum Response {
     Exec(Result<String, RpcMessageError>),
     GetExecBatchResults(Result<Vec<ExeScriptCommandResult>, RpcMessageError>),
+    GetRunningCommand(Result<ExeScriptCommandState, RpcMessageError>),
     Error(RpcMessageError),
 }
 

--- a/model/src/activity/sgx_credentials.rs
+++ b/model/src/activity/sgx_credentials.rs
@@ -9,6 +9,8 @@ pub struct SgxCredentials {
     pub requestor_pub_key: PublicKey,
     #[serde(rename = "payloadHash")]
     pub payload_hash: String,
+    #[serde(rename = "enclaveHash")]
+    pub enclave_hash: String,
     #[serde(rename = "iasReport")]
     pub ias_report: String,
     #[serde(rename = "iasSig", with = "binenc")]
@@ -22,6 +24,7 @@ impl SgxCredentials {
         enclave_pub_key: PublicKey,
         requestor_pub_key: PublicKey,
         payload_hash: String,
+        enclave_hash: String,
         ias_report: String,
         ias_sig: Vec<u8>,
         session_key: Vec<u8>,
@@ -30,10 +33,31 @@ impl SgxCredentials {
             enclave_pub_key,
             requestor_pub_key,
             payload_hash,
+            enclave_hash,
             ias_report,
             ias_sig,
             session_key,
         }
+    }
+
+    pub fn try_with(
+        enclave_pub_key: Vec<u8>,
+        requestor_pub_key: Vec<u8>,
+        payload_hash: String,
+        enclave_hash: String,
+        ias_report: String,
+        ias_sig: Vec<u8>,
+        session_key: Vec<u8>,
+    ) -> Result<Self, secp256k1::Error> {
+        Ok(Self::new(
+            PublicKey::from_slice(enclave_pub_key.as_slice())?,
+            PublicKey::from_slice(requestor_pub_key.as_slice())?,
+            payload_hash,
+            enclave_hash,
+            ias_report,
+            ias_sig,
+            session_key,
+        ))
     }
 }
 

--- a/model/src/activity/sgx_credentials.rs
+++ b/model/src/activity/sgx_credentials.rs
@@ -39,7 +39,6 @@ impl SgxCredentials {
 
 mod binenc {
     use super::*;
-    use base64;
     use serde::de::Error;
     use serde::{Deserializer, Serializer};
 
@@ -47,7 +46,7 @@ mod binenc {
     where
         S: Serializer,
     {
-        let s = base64::encode(&bytes);
+        let s = hex::encode(&bytes);
         serializer.serialize_str(&s)
     }
 
@@ -56,8 +55,7 @@ mod binenc {
         D: Deserializer<'de>,
     {
         let s = String::deserialize(deserializer)?;
-
-        let bytes = base64::decode(&s).map_err(D::Error::custom)?;
+        let bytes = hex::decode(&s).map_err(D::Error::custom)?;
         Ok(bytes)
     }
 }

--- a/specs/activity-api.yaml
+++ b/specs/activity-api.yaml
@@ -467,20 +467,20 @@ components:
       properties:
         enclavePubKey:
           type: string
-          format: base64
+          format: hex
         requestorPubKey:
           type: string
-          format: byte
+          format: hex
         payloadHash:
           type: string
         iasReport:
           type: string
         iasSig:
           type: string
-          format: byte
+          format: hex
         sessionKey:
           type: string
-          format: byte
+          format: hex
 
     ExeScriptRequest:
       required:

--- a/src/activity.rs
+++ b/src/activity.rs
@@ -7,4 +7,7 @@ pub use requestor::control::ActivityRequestorControlApi;
 pub use requestor::state::ActivityRequestorStateApi;
 pub use requestor::ActivityRequestorApi;
 
+#[cfg(feature = "sgx")]
+pub use requestor::control::sgx::SecureActivityRequestorApi;
+
 pub(crate) const ACTIVITY_URL_ENV_VAR: &str = "YAGNA_ACTIVITY_URL";

--- a/src/activity/requestor/control.rs
+++ b/src/activity/requestor/control.rs
@@ -158,6 +158,10 @@ pub mod sgx {
             Ok(SecureActivityRequestorApi { client, session })
         }
 
+        pub fn activity_id(&self) -> String {
+            self.session.activity_id.clone()
+        }
+
         pub async fn exec(&self, exe_script: Vec<ExeScriptCommand>) -> Result<String> {
             let request = enc::Request {
                 activity_id: self.session.activity_id.clone(),


### PR DESCRIPTION
- use hex encoding in #39
- extend `SgxCredentials` model