### PR TITLE
[Market API] Flat JSON properties spec added to market-api.yaml

### DIFF
--- a/specs/market-api.yaml
+++ b/specs/market-api.yaml
@@ -944,15 +944,18 @@ components:
           description: >
             The object which includes all the Demand/Offer properties.
 
-            This is a JSON object in "flat convention" - where keys are full property names and their values indicate properties.
+            - Client and server accepts all JSON formats when submitting Demands/Offers to REST API.
+            - "flat format" is mandatory when returning Demands/Offers from REST API
 
+            By "flat format" we mean single level key-value map, where keys are full property names
+            and their values indicate properties.
 
-            The value's Javascript type shall conform with the type of the property (as indicated in Golem Standards).
+            The value's Javascript type shall conform with the type of the property
+            (as indicated in Golem Standards).
 
             ### Example property object:
 
             ```
-
             {
               "golem.com.pricing.model":"linear",
               "golem.com.pricing.model.linear.coeffs":[0.001, 0.002, 0.0],
@@ -969,9 +972,7 @@ components:
               "golem.runtime.name":"vm",
               "golem.runtime.version@v":"0.1.0"
             }
-
             ```
-
           type: object
         constraints:
           type: string

--- a/specs/market-api.yaml
+++ b/specs/market-api.yaml
@@ -941,6 +941,37 @@ components:
         - constraints
       properties:
         properties:
+          description: >
+            The object which includes all the Demand/Offer properties.
+
+            This is a JSON object in "flat convention" - where keys are full property names and their values indicate properties.
+
+
+            The value's Javascript type shall conform with the type of the property (as indicated in Golem Standards).
+
+            ### Example property object:
+
+            ```
+
+            {
+              "golem.com.pricing.model":"linear",
+              "golem.com.pricing.model.linear.coeffs":[0.001, 0.002, 0.0],
+              "golem.com.scheme":"payu",
+              "golem.com.scheme.payu.interval_sec":6.0,
+              "golem.com.usage.vector":["golem.usage.duration_sec","golem.usage.cpu_sec"],
+              "golem.inf.cpu.architecture":"x86_64",
+              "golem.inf.cpu.cores":4,
+              "golem.inf.cpu.threads":7,
+              "golem.inf.mem.gib":10.612468048930168,
+              "golem.inf.storage.gib":81.7227783203125,
+              "golem.node.debug.subnet":"market-devnet",
+              "golem.node.id.name":"tworec@mf-market-devnet",
+              "golem.runtime.name":"vm",
+              "golem.runtime.version@v":"0.1.0"
+            }
+
+            ```
+
           type: object
         constraints:
           type: string


### PR DESCRIPTION
As per Tech Council action (https://www.notion.so/golemnetwork/87c28c874fc54d76845127946e72e3a7?v=2fe57c56530c41839e6bbcf222c026e2&p=2829f9bebd0549d6839db344b8e41e32) - flat JSON format has been sanctioned as mandatory for Demand/Offer properties. 