### PR TITLE
Runtime output format and capture options

### DIFF
--- a/model/src/activity.rs
+++ b/model/src/activity.rs
@@ -9,8 +9,9 @@ pub mod runtime_event;
 
 pub use self::activity_state::{ActivityState, State, StatePair};
 pub use self::activity_usage::ActivityUsage;
+pub use self::exe_script_command::{Capture, CaptureFormat, CaptureMode, CapturePart};
 pub use self::exe_script_command::{ExeScriptCommand, FileSet, SetEntry, SetObject, TransferArgs};
-pub use self::exe_script_command_result::{ExeScriptCommandResult, Result as CommandResult};
+pub use self::exe_script_command_result::{CommandOutput, CommandResult, ExeScriptCommandResult};
 pub use self::exe_script_command_state::ExeScriptCommandState;
 pub use self::exe_script_request::ExeScriptRequest;
 pub use self::provider_event::ProviderEvent;

--- a/model/src/activity/exe_script_command_result.rs
+++ b/model/src/activity/exe_script_command_result.rs
@@ -11,17 +11,25 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ExeScriptCommandResult {
     pub index: u32,
-    pub result: Result,
-    #[serde(rename = "isBatchFinished")]
-    pub is_batch_finished: bool,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    pub result: CommandResult,
+    pub stdout: Option<CommandOutput>,
+    pub stderr: Option<CommandOutput>,
     pub message: Option<String>,
+    pub is_batch_finished: bool,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum CommandOutput {
+    Str(String),
+    Bin(Vec<u8>),
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
-pub enum Result {
+pub enum CommandResult {
     Ok,
     Error,
 }

--- a/model/src/activity/runtime_event.rs
+++ b/model/src/activity/runtime_event.rs
@@ -1,4 +1,4 @@
-use crate::activity::ExeScriptCommand;
+use crate::activity::{CommandOutput, ExeScriptCommand};
 use chrono::{NaiveDateTime, Utc};
 use serde::{Deserialize, Serialize};
 
@@ -40,11 +40,11 @@ impl RuntimeEvent {
         )
     }
 
-    pub fn stdout(batch_id: String, idx: usize, out: String) -> Self {
+    pub fn stdout(batch_id: String, idx: usize, out: CommandOutput) -> Self {
         Self::new(batch_id, idx, RuntimeEventKind::StdOut(out))
     }
 
-    pub fn stderr(batch_id: String, idx: usize, out: String) -> Self {
+    pub fn stderr(batch_id: String, idx: usize, out: CommandOutput) -> Self {
         Self::new(batch_id, idx, RuntimeEventKind::StdErr(out))
     }
 }
@@ -59,6 +59,6 @@ pub enum RuntimeEventKind {
         return_code: i32,
         message: Option<String>,
     },
-    StdOut(String),
-    StdErr(String),
+    StdOut(CommandOutput),
+    StdErr(CommandOutput),
 }

--- a/specs/activity-api.yaml
+++ b/specs/activity-api.yaml
@@ -416,6 +416,10 @@ components:
           enum:
             - Ok
             - Error
+        stdout:
+          type: string
+        stderr:
+          type: string
         message:
           type: string
         isBatchFinished:


### PR DESCRIPTION
Introduces a new `capture` parameter to the `RUN` command. The new parameter MUST be included or the output will be discarded.

```json
"run": {
   ...
    "capture": {
        "stdout": { "atEnd": { "head": 64000, "format": "bin" } },
        "stderr": { "stream": { "limit": 128000, "format": "str" } },
    }
}
```

each of `stdout` and `stderr` may contain either:
- `atEnd` - capture output when the command finishes
  - optionally limit the captured output size with `"head" | "tail" | "headTail"`, leave blank for unlimited output
  - optionally specify output `format` 
- `stream`
  - optionally limit the stream output size with `"limit"`, skip for unlimited output
  - optionally specify output `format` 

* `capture`: `"stdout" | "stderr"`
* `limit`: `usize`, defaults to null (no limit)
* `format`: `"bin" | "str"`, defaults to `"str"`


Requires #33