### PR TITLE
[mkt spec] Make REST responses compliant with standard HTTP Codes semantics

### DIFF
--- a/specs/market-api.yaml
+++ b/specs/market-api.yaml
@@ -585,7 +585,11 @@ paths:
         401:
           $ref: 'common.yaml#/responses/Unauthorized'
         409:
-          description: Proposal not in `Draft` state.
+          $ref: 'common.yaml#/responses/Conflict'
+          description: Proposal not negotiated yet (in `Initial` state).
+        410:
+          $ref: 'common.yaml#/responses/Gone'
+          description: Proposal rejected or expired.
         default:
           $ref: 'common.yaml#/responses/UnexpectedError'
 
@@ -633,10 +637,9 @@ paths:
           $ref: 'common.yaml#/responses/Unauthorized'
         404:
           $ref: 'common.yaml#/responses/NotFound'
-        409:
-          description: Agreement not in `Proposal` nor `Pending` state.
         410:
-          $ref: 'common.yaml#/responses/Gone' # Expired
+          $ref: 'common.yaml#/responses/Gone'
+          description: Agreement not in `Proposal` nor `Pending` state.
         default:
           $ref: 'common.yaml#/responses/UnexpectedError'
 
@@ -665,10 +668,9 @@ paths:
           $ref: 'common.yaml#/responses/Unauthorized'
         404:
           $ref: 'common.yaml#/responses/NotFound'
-        409:
-          description: Agreement not in `Proposal` nor `Pending` state.
         410:
-          $ref: 'common.yaml#/responses/Gone' # Expired
+          $ref: 'common.yaml#/responses/Gone'
+          description: Agreement not in `Proposal` nor `Pending` state.
         default:
           $ref: 'common.yaml#/responses/UnexpectedError'
 
@@ -689,13 +691,12 @@ paths:
       responses:
         204:
           description: Agreement confirmed.
-        400:
-          $ref: 'common.yaml#/responses/BadRequest' # when called for cancelled agreement
         401:
           $ref: 'common.yaml#/responses/Unauthorized'
         404:
           $ref: 'common.yaml#/responses/NotFound'
-        409:
+        410:
+          $ref: 'common.yaml#/responses/Gone'
           description: Agreement not in `Proposal` state.
         default:
           $ref: 'common.yaml#/responses/UnexpectedError'
@@ -711,37 +712,44 @@ paths:
       summary: WaitForApproval - Waits for Agreement approval by the Provider.
       description: >
         This is a blocking operation. The call may be aborted by Requestor caller
-        code. After the call is aborted, another `waitForApproval` call can be
-        raised on the same Agreement Id.
-
-
-        It returns one of the following options:
-
-        * `Approved` - Indicates that the Agreement has been approved by the Provider.
-          - The Provider is now ready to accept a request to start an Activity
-            as described in the negotiated agreement.
-          - The Providers’s corresponding `approveAgreement` call returns `Approved` after
-            this on the Provider side.
-
-        * `Rejected` - Indicates that the Provider has called `rejectAgreement`,
-          which effectively stops the Agreement handshake. The Requestor may attempt
-          to return to the Negotiation phase by sending a new Proposal.
-
-        * `Cancelled` - Indicates that the Requestor himself has called
-          `cancelAgreement`, which effectively stops the Agreement handshake.
+        code. After the call is aborted or timed out, another `waitForApproval`
+        call can be raised on the same Agreement Id.
       responses:
-        200:
-          description: Agreement approved.
+        204:
+          description: >
+            Agreement approved by the Provider.
+
+
+            The Providers’s corresponding `approveAgreement` call returns `204`
+            (Approved) **before** this endpoint on the Requestor side.
+            The Provider is now ready to accept a request to start an Activity.
         401:
           $ref: 'common.yaml#/responses/Unauthorized'
         404:
           $ref: 'common.yaml#/responses/NotFound'
         408:
           $ref: 'common.yaml#/responses/Timeout'
+          description: Agreement not approved within given timeout. Try again.
         409:
-          description: Agreement not in `Pending` state.
+          $ref: 'common.yaml#/responses/Conflict'
+          description: Agreement not confirmed yet by Requestor himself.
         410:
-          $ref: 'common.yaml#/responses/Gone' # Agreement Rejected
+          $ref: 'common.yaml#/responses/Gone'
+          description: >
+            Agreement is not approved. This state is permanent.
+
+
+            Attached `ErrorMessage` contains further details:
+              - `Rejected` - Indicates that the Provider has called
+                `rejectAgreement`, which effectively stops the Agreement handshake.
+                The Requestor may attempt to return to the Negotiation phase by
+                sending a new Proposal or to the Agreement phase by creating
+                new Agreement.
+              - `Cancelled` - Indicates that the Requestor himself has called
+                `cancelAgreement`, which effectively stops the Agreement handshake.
+              - `Expired` - Indicates that Agreement validity period elapsed and it
+                was not approved, rejected nor cancelled.
+              - `Terminated` - Indicates that Agreement is already terminated.
         default:
           $ref: 'common.yaml#/responses/UnexpectedError'
 
@@ -760,6 +768,7 @@ paths:
       description: >
         This is a blocking operation. It will not return until there is
         at least one new event. All events are appearing on both sides equally.
+
 
         Returns Agreement related events:
 
@@ -807,23 +816,6 @@ paths:
         call can be raised on the same `agreementId`.
 
 
-        It returns one of the following options:
-
-        * `Approved` - Indicates that the approved Agreement has been successfully
-        delivered to the Requestor and acknowledged.
-          - The Requestor side has been notified about the Provider’s commitment
-            to the Agreement.
-          - The Provider is now ready to accept a request to start an Activity
-            as described in the negotiated agreement.
-          - The Requestor’s corresponding `waitForApproval` call returns `Approved` after
-            the one on the Provider side.
-
-        * `Cancelled` - Indicates that before delivering the approved Agreement,
-        the Requestor has called `cancelAgreement`, thus invalidating the
-        Agreement. The Provider may attempt to return to the Negotiation phase
-        by sending a new Proposal.
-
-
         **Note**: It is expected from the Provider node implementation to “ring-fence”
         the resources required to fulfill the Agreement before the ApproveAgreement
         is sent. However, the resources should not be fully committed until `Approved`
@@ -832,18 +824,39 @@ paths:
 
         **Note**: Mutually exclusive with `rejectAgreement`.
       responses:
-        200:
-          description: Agreement approved.
+        204:
+          description: >
+            Agreement approved.
+
+            Indicates that the approved Agreement has been successfully
+            delivered to the Requestor and acknowledged.
+              - The Requestor side has been notified about the Provider’s commitment.
+              - The Provider is now ready to accept a request to start an Activity.
+              - The Requestor’s corresponding `waitForApproval` call returns `204`
+                (Approved) **after** this endpoint on the Provider side.
         401:
           $ref: 'common.yaml#/responses/Unauthorized'
         404:
           $ref: 'common.yaml#/responses/NotFound'
         408:
           $ref: 'common.yaml#/responses/Timeout'
-        409:
-          description: Agreement not in `Proposal` state.
+          description: Agreement not approved within given timeout. Try again.
         410:
-          $ref: 'common.yaml#/responses/Gone'  # Agreement Cancelled
+          $ref: 'common.yaml#/responses/Gone'
+          description: >
+            Agreement approval failed permanently.
+
+
+            Attached `ErrorMessage` contains further details:
+              - `Rejected` - Indicates that the Provider himself has already
+                called `rejectAgreement`.
+              - `Cancelled` - Indicates that before Provider approved this Agreement,
+                the Requestor has called `cancelAgreement`, thus invalidating the
+                Agreement. The Provider may attempt to return to the Negotiation phase
+                by sending a new Proposal.
+              - `Expired` - Indicates that Agreement validity period elapsed and it was
+                not approved, rejected nor cancelled.
+              - `Terminated` - Indicates that Agreement is already terminated.
         default:
           $ref: 'common.yaml#/responses/UnexpectedError'
 
@@ -859,6 +872,7 @@ paths:
         The Requestor side is notified about the Provider’s decision to reject
         a negotiated agreement. This effectively stops the Agreement handshake.
 
+
         **Note**: Mutually exclusive with `approveAgreement`.
       requestBody:
         $ref: '#/components/requestBodies/Reason'
@@ -869,10 +883,22 @@ paths:
           $ref: 'common.yaml#/responses/Unauthorized'
         404:
           $ref: 'common.yaml#/responses/NotFound'
-        409:
-          description: Agreement not in `Proposal` state.
         410:
-          $ref: 'common.yaml#/responses/Gone' # Expired
+          $ref: 'common.yaml#/responses/Gone'
+          description: >
+            Agreement rejection failed permanently.
+
+
+            Attached `ErrorMessage` contains further details:
+              - `Rejected` - Indicates that the Provider himself has already
+                called `rejectAgreement`.
+              - `Cancelled` - Indicates that before Provider rejected this Agreement,
+                the Requestor has called `cancelAgreement`, thus invalidating the
+                Agreement. The Provider may attempt to return to the Negotiation phase
+                by sending a new Proposal.
+              - `Expired` - Indicates that Agreement validity period elapsed and it was
+                not approved, rejected nor cancelled.
+              - `Terminated` - Indicates that Agreement is already terminated.
         default:
           $ref: 'common.yaml#/responses/UnexpectedError'
 
@@ -888,11 +914,14 @@ paths:
       description: >
         Method to finish/close the Agreement while in `Approved` state.
 
+
         The other party gets notified about calling party decision to
         terminate a "running" agreement.
 
+
         **Note**: Can be invoked at any time after Agreement was approved
         by both sides.
+
 
         **Note**: Financial and reputational consequences are not
         defined by this specification.
@@ -906,9 +935,20 @@ paths:
         404:
           $ref: 'common.yaml#/responses/NotFound'
         409:
-          description: Agreement not in `Approved` state.
+          $ref: 'common.yaml#/responses/Conflict'
+          description: Agreement can not be terminated yet (is in `Proposal` or `Pending` state).
         410:
           $ref: 'common.yaml#/responses/Gone'
+          description: >
+            Agreement termination failed permanently.
+
+
+            Attached `ErrorMessage` contains further details:
+              - `Rejected` - Indicates that the Provider has rejected this Agreement.
+              - `Cancelled` - Indicates the Requestor has called cancelled this Agreement.
+              - `Expired` - Indicates that Agreement validity period elapsed and it was
+                not approved, rejected nor cancelled.
+              - `Terminated` - Indicates that Agreement is already terminated.
         default:
           $ref: 'common.yaml#/responses/UnexpectedError'
 
@@ -1063,7 +1103,8 @@ components:
       description: >
         End of validity period.
 
-        Agreement needs to be accepted, rejected or cancelled before this date;
+
+        Agreement needs to be approved, rejected or cancelled before this date;
         otherwise will expire.
 
 
@@ -1223,7 +1264,7 @@ components:
           type: string
           enum: [Proposal, Pending, Cancelled, Rejected, Approved, Expired, Terminated]
           description: >
-            * `Proposal` - newly created by a Requestor (based on Proposal)
+            * `Proposal` - newly created by a Requestor (draft based on Proposal)
 
             * `Pending` - confirmed by a Requestor and send to Provider for approval
 
@@ -1233,7 +1274,7 @@ components:
 
             * `Approved` by both sides
 
-            * `Expired` - not accepted, rejected nor cancelled within validity period
+            * `Expired` - not approved, rejected nor cancelled within validity period
 
             * `Terminated` - finished after approval.
         timestamp:

--- a/specs/market-api.yaml
+++ b/specs/market-api.yaml
@@ -796,7 +796,8 @@ paths:
         401:
           $ref: 'common.yaml#/responses/Unauthorized'
         404:
-          $ref: 'common.yaml#/responses/NotFound'  # for invalid appSessionId
+          $ref: 'common.yaml#/responses/NotFound'
+          description: Unknown appSessionId given.
         default:
           $ref: 'common.yaml#/responses/UnexpectedError'
 


### PR DESCRIPTION
Partly suggested by @prekucki here:
https://github.com/golemfactory/yagna/pull/765/files#r524684289