### PR TITLE
Event API: Python code generation schema fix

### DIFF
--- a/specs/payment-api.yaml
+++ b/specs/payment-api.yaml
@@ -1224,51 +1224,51 @@ components:
       allOf:
         - $ref: '#/components/schemas/DebitNoteEvent'
         - type: object
-      properties:
-        debitNoteId:
-          type: string
+          properties:
+            debitNoteId:
+              type: string
 
     DebitNoteAcceptedEvent:
       allOf:
         - $ref: '#/components/schemas/DebitNoteEvent'
         - type: object
-      properties:
-        debitNoteId:
-          type: string
+          properties:
+            debitNoteId:
+              type: string
 
     DebitNoteRejectedEvent:
       allOf:
         - $ref: '#/components/schemas/DebitNoteEvent'
         - type: object
-      properties:
-        debitNoteId:
-          type: string
-        rejection:
-          $ref: '#/components/schemas/Rejection'
+          properties:
+            debitNoteId:
+              type: string
+            rejection:
+              $ref: '#/components/schemas/Rejection'
 
     DebitNoteFailedEvent:
       allOf:
         - $ref: '#/components/schemas/DebitNoteEvent'
         - type: object
-      properties:
-        debitNoteId:
-          type: string
+          properties:
+            debitNoteId:
+              type: string
 
     DebitNoteSettledEvent:
       allOf:
         - $ref: '#/components/schemas/DebitNoteEvent'
         - type: object
-      properties:
-        debitNoteId:
-          type: string
+          properties:
+            debitNoteId:
+              type: string
 
     DebitNoteCancelledEvent:
       allOf:
         - $ref: '#/components/schemas/DebitNoteEvent'
         - type: object
-      properties:
-        debitNoteId:
-          type: string
+          properties:
+            debitNoteId:
+              type: string
 
     InvoiceEvent:
       type: object

--- a/specs/payment-api.yaml
+++ b/specs/payment-api.yaml
@@ -1288,59 +1288,59 @@ components:
       allOf:
         - $ref: '#/components/schemas/InvoiceEvent'
         - type: object
-      properties:
-        invoiceId:
-          type: string
+          properties:
+            invoiceId:
+              type: string
 
     InvoiceAcceptedEvent:
       allOf:
         - $ref: '#/components/schemas/InvoiceEvent'
         - type: object
-      properties:
-        invoiceId:
-          type: string
+          properties:
+            invoiceId:
+              type: string
 
     InvoiceRejectedEvent:
       allOf:
         - $ref: '#/components/schemas/InvoiceEvent'
         - type: object
-      properties:
-        invoiceId:
-          type: string
-        rejection:
-          $ref: '#/components/schemas/Rejection'
+          properties:
+            invoiceId:
+              type: string
+            rejection:
+              $ref: '#/components/schemas/Rejection'
 
     InvoiceFailedEvent:
       allOf:
         - $ref: '#/components/schemas/InvoiceEvent'
         - type: object
-      properties:
-        invoiceId:
-          type: string
+          properties:
+            invoiceId:
+              type: string
 
     InvoiceSettledEvent:
       allOf:
         - $ref: '#/components/schemas/InvoiceEvent'
         - type: object
-      properties:
-        invoiceId:
-          type: string
+          properties:
+            invoiceId:
+              type: string
 
     InvoiceCancelledEvent:
       allOf:
         - $ref: '#/components/schemas/InvoiceEvent'
         - type: object
-      properties:
-        invoiceId:
-          type: string
+          properties:
+            invoiceId:
+              type: string
 
     PaymentReceivedEvent:
       allOf:
         - $ref: '#/components/schemas/InvoiceEvent'
         - type: object
-      properties:
-        paymentId:
-          type: string
+          properties:
+            paymentId:
+              type: string
 
     Account:
       description: Payment account (wallet)


### PR DESCRIPTION
Fixes a code generation error:

```java
Exception in thread "main" java.lang.RuntimeException: Could not process model 'DebitNoteEvent'.Please make sure that your schema is correct!
        at org.openapitools.codegen.DefaultGenerator.generateModels(DefaultGenerator.java:496)
        at org.openapitools.codegen.DefaultGenerator.generate(DefaultGenerator.java:1005)
        at org.openapitools.codegen.cmd.Generate.execute(Generate.java:431)
        at org.openapitools.codegen.cmd.OpenApiGeneratorCommand.run(OpenApiGeneratorCommand.java:32)
        at org.openapitools.codegen.OpenAPIGenerator.main(OpenAPIGenerator.java:61)
Caused by: java.lang.RuntimeException: Invalid inline schema defined in allOf in 'InvoiceReceivedEvent'. Per the OpenApi spec, for this case when a composed schema defines a discriminator, the allOf schemas must use $ref. Change this inline definition to a $ref definition
        at org.openapitools.codegen.DefaultCodegen.getAllOfDescendants(DefaultCodegen.java:2665)
        at org.openapitools.codegen.DefaultCodegen.createDiscriminator(DefaultCodegen.java:2722)
        at org.openapitools.codegen.DefaultCodegen.fromModel(DefaultCodegen.java:2152)
        at org.openapitools.codegen.DefaultGenerator.processModels(DefaultGenerator.java:1289)
        at org.openapitools.codegen.DefaultGenerator.generateModels(DefaultGenerator.java:491)
        ... 4 more
```