### PR TITLE
Moved all query string serialization in payment api to 'serde_qs'

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ rand = "0.6"
 mime = "0.3"
 serde = "1.0"
 serde_json = "1.0"
+serde_qs = "0.8"
 thiserror = "1.0"
 url = "2.1"
 

--- a/model/src/payment.rs
+++ b/model/src/payment.rs
@@ -9,6 +9,7 @@ pub mod document_status;
 pub mod invoice;
 pub mod invoice_event;
 pub mod market_decoration;
+pub mod params;
 pub mod payment;
 pub mod rejection;
 pub mod rejection_reason;

--- a/model/src/payment/params.rs
+++ b/model/src/payment/params.rs
@@ -1,0 +1,80 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Deserializer, Serialize};
+
+pub const DEFAULT_ACK_TIMEOUT: f64 = 60.0; // seconds
+pub const DEFAULT_EVENT_TIMEOUT: f64 = 0.0; // seconds
+
+#[derive(Deserialize, Serialize)]
+pub struct DebitNoteId {
+    pub debit_note_id: String,
+}
+
+#[derive(Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DebitNotePaymentsParams {
+    pub debit_note_id: String,
+    #[serde(default)]
+    pub max_items: Option<u32>,
+    #[serde(default)]
+    pub after_timestamp: Option<DateTime<Utc>>,
+}
+
+#[derive(Deserialize, Serialize)]
+pub struct InvoiceId {
+    pub invoice_id: String,
+}
+
+#[derive(Deserialize, Serialize)]
+pub struct AllocationId {
+    pub allocation_id: String,
+}
+
+#[derive(Deserialize, Serialize)]
+pub struct PaymentId {
+    pub payment_id: String,
+}
+
+#[derive(Deserialize, Serialize)]
+pub struct Timeout {
+    #[serde(default)]
+    pub timeout: Option<f64>,
+}
+
+#[derive(Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EventParams {
+    #[serde(default)]
+    pub poll_timeout: Option<f64>,
+    #[serde(default)]
+    pub after_timestamp: Option<DateTime<Utc>>,
+    #[serde(default)]
+    pub max_events: Option<u32>,
+    #[serde(default)]
+    pub app_session_id: Option<String>,
+}
+
+#[derive(Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FilterParams {
+    #[serde(default)]
+    pub max_items: Option<u32>,
+    #[serde(default)]
+    pub after_timestamp: Option<DateTime<Utc>>,
+}
+
+#[derive(Deserialize, Serialize)]
+pub struct AllocationIds {
+    #[serde(
+        rename = "allocationIds",
+        deserialize_with = "deserialize_comma_separated"
+    )]
+    pub allocation_ids: Vec<String>,
+}
+
+fn deserialize_comma_separated<'de, D>(deserializer: D) -> Result<Vec<String>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let s: &str = Deserialize::deserialize(deserializer)?;
+    Ok(s.split(",").map(str::to_string).collect())
+}

--- a/src/web.rs
+++ b/src/web.rs
@@ -9,6 +9,7 @@ use futures::stream::Peekable;
 use futures::{Stream, StreamExt, TryStreamExt};
 use heck::MixedCase;
 use serde::{de::DeserializeOwned, Serialize};
+use serde_qs;
 use std::cmp::max;
 use std::convert::TryFrom;
 use std::pin::Pin;
@@ -510,6 +511,18 @@ macro_rules! url_format {
         }
         url
     }};
+}
+
+pub fn url_format_obj<T>(base: &str, params: &T) -> String
+where
+    T: Serialize,
+{
+    let qs = serde_qs::to_string(params).unwrap_or("".to_string());
+    if qs.len() > 0 {
+        format!("{}?{}", base, qs)
+    } else {
+        base.to_string()
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
**Please do not merge until all `event-api/master`'s are properly merged**

Cleanup after event api, no changes to logic.
- Moved query param objects to payments model
- Updated client api to use these for serialisation
- Moved defaults to be set on the server side