### PR TITLE
[act,pay] `pollTimeout` has specified name `timeout`

### DIFF
--- a/.github/workflows/code-check.yml
+++ b/.github/workflows/code-check.yml
@@ -1,4 +1,5 @@
 name: Code Check
+
 on:
   push:
     branches:
@@ -6,6 +7,7 @@ on:
   pull_request:
     branches:
       - master
+      - release/*
 
 jobs:
   pre-commit:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,9 +2,12 @@ name: CI
 
 on:
   push:
-    branches: [ master ]
+    branches:
+      - master
   pull_request:
-    branches: [ master ]
+    branches:
+      - master
+      - release/*
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,9 +17,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        # commented bc of too much spend on Macos which is counted 10x, Windows is 2x
-        # os: [macos-latest, windows-latest, ubuntu-latest]
-        os: [windows-latest, ubuntu-latest]
+        os: [macos-latest, windows-latest, ubuntu-latest]
 
     steps:
       - name: Checkout

--- a/model/src/payment/debit_note_event.rs
+++ b/model/src/payment/debit_note_event.rs
@@ -32,7 +32,7 @@ pub enum DebitNoteEventType {
 mod test {
     use super::*;
     use crate::payment::{Rejection, RejectionReason};
-    use bigdecimal::BigDecimal;
+    use bigdecimal::{BigDecimal, FromPrimitive};
     use chrono::TimeZone;
 
     #[test]
@@ -45,7 +45,7 @@ mod test {
             event_type: DebitNoteEventType::DebitNoteRejectedEvent {
                 rejection: Rejection {
                     rejection_reason: RejectionReason::UnsolicitedService,
-                    total_amount_accepted: BigDecimal::from(3.14),
+                    total_amount_accepted: BigDecimal::from_f32(3.14).unwrap(),
                     message: None,
                 },
             },
@@ -57,7 +57,7 @@ mod test {
                 \"eventType\":\"DebitNoteRejectedEvent\",\
                 \"rejection\":{\
                     \"rejectionReason\":\"UNSOLICITED_SERVICE\",\
-                    \"totalAmountAccepted\":\"3.140000000000000\"\
+                    \"totalAmountAccepted\":\"3.140000\"\
                 }\
              }",
             serde_json::to_string(&ie).unwrap()

--- a/model/src/payment/invoice_event.rs
+++ b/model/src/payment/invoice_event.rs
@@ -32,7 +32,7 @@ pub enum InvoiceEventType {
 mod test {
     use super::*;
     use crate::payment::{Rejection, RejectionReason};
-    use bigdecimal::BigDecimal;
+    use bigdecimal::{BigDecimal, FromPrimitive};
     use chrono::TimeZone;
 
     #[test]
@@ -45,7 +45,7 @@ mod test {
             event_type: InvoiceEventType::InvoiceRejectedEvent {
                 rejection: Rejection {
                     rejection_reason: RejectionReason::UnsolicitedService,
-                    total_amount_accepted: BigDecimal::from(3.14),
+                    total_amount_accepted: BigDecimal::from_f32(3.14).unwrap(),
                     message: None,
                 },
             },
@@ -57,7 +57,7 @@ mod test {
                 \"eventType\":\"InvoiceRejectedEvent\",\
                 \"rejection\":{\
                     \"rejectionReason\":\"UNSOLICITED_SERVICE\",\
-                    \"totalAmountAccepted\":\"3.140000000000000\"\
+                    \"totalAmountAccepted\":\"3.140000\"\
                 }\
              }",
             serde_json::to_string(&ie).unwrap()

--- a/model/src/payment/params.rs
+++ b/model/src/payment/params.rs
@@ -44,7 +44,7 @@ pub struct Timeout {
 #[serde(rename_all = "camelCase")]
 pub struct EventParams {
     #[serde(default)]
-    pub poll_timeout: Option<f64>,
+    pub timeout: Option<f64>,
     #[serde(default)]
     pub after_timestamp: Option<DateTime<Utc>>,
     #[serde(default)]

--- a/src/activity/provider.rs
+++ b/src/activity/provider.rs
@@ -50,16 +50,16 @@ impl ActivityProviderApi {
         &self,
         after_timestamp: Option<DateTime<Utc>>,
         app_session_id: Option<String>,
-        poll_timeout: Option<Duration>,
+        timeout: Option<Duration>,
         max_events: Option<u32>,
     ) -> Result<Vec<ProviderEvent>> {
         let after_timestamp = after_timestamp.map(|ts| ts.to_rfc3339());
-        let poll_timeout = poll_timeout.map(|d| d.as_secs_f32());
+        let timeout = timeout.map(|d| d.as_secs_f32());
         let url = url_format!(
             "events",
             #[query] after_timestamp,
             #[query] app_session_id,
-            #[query] poll_timeout,
+            #[query] timeout,
             #[query] max_events,
         );
 

--- a/src/payment/api.rs
+++ b/src/payment/api.rs
@@ -175,7 +175,7 @@ impl PaymentApi {
     pub async fn get_debit_note_events<Tz>(
         &self,
         after_timestamp: Option<&DateTime<Tz>>,
-        poll_timeout: Option<Duration>,
+        timeout: Option<Duration>,
         max_events: Option<u32>,
         app_session_id: Option<String>,
     ) -> Result<Vec<DebitNoteEvent>>
@@ -185,7 +185,7 @@ impl PaymentApi {
     {
         let input = params::EventParams {
             after_timestamp: after_timestamp.map(|dt| dt.with_timezone(&Utc)),
-            poll_timeout: poll_timeout.map(|d| d.as_secs_f64()),
+            timeout: timeout.map(|d| d.as_secs_f64()),
             max_events,
             app_session_id,
         };
@@ -304,7 +304,7 @@ impl PaymentApi {
     pub async fn get_invoice_events<Tz>(
         &self,
         after_timestamp: Option<&DateTime<Tz>>,
-        poll_timeout: Option<Duration>,
+        timeout: Option<Duration>,
         max_events: Option<u32>,
         app_session_id: Option<String>,
     ) -> Result<Vec<InvoiceEvent>>
@@ -314,7 +314,7 @@ impl PaymentApi {
     {
         let input = params::EventParams {
             after_timestamp: after_timestamp.map(|dt| dt.with_timezone(&Utc)),
-            poll_timeout: poll_timeout.map(|d| d.as_secs_f64()),
+            timeout: timeout.map(|d| d.as_secs_f64()),
             max_events,
             app_session_id,
         };
@@ -379,7 +379,7 @@ impl PaymentApi {
     pub async fn get_payments<Tz>(
         &self,
         after_timestamp: Option<&DateTime<Tz>>,
-        poll_timeout: Option<Duration>,
+        timeout: Option<Duration>,
         max_events: Option<u32>,
         app_session_id: Option<String>,
     ) -> Result<Vec<Payment>>
@@ -389,7 +389,7 @@ impl PaymentApi {
     {
         let input = params::EventParams {
             after_timestamp: after_timestamp.map(|dt| dt.with_timezone(&Utc)),
-            poll_timeout: poll_timeout.map(|d| d.as_secs_f64()),
+            timeout: timeout.map(|d| d.as_secs_f64()),
             max_events,
             app_session_id,
         };


### PR DESCRIPTION
conform to [common.yaml](https://github.com/golemfactory/ya-client/blob/master/specs/common.yaml#L7) spec where `pollTimeout` is defined to… have name `timeout`

It also contains changes from `release/v0.6` created by @maaktweluit (but we agree it should be removed).

I'm also turning on CI for `release/*` branches and restoring macOS builds.