### PR TITLE
Implemented AsRef<[u8; 20]> for NodeId

### DIFF
--- a/model/src/node_id.rs
+++ b/model/src/node_id.rs
@@ -69,6 +69,12 @@ impl AsRef<[u8]> for NodeId {
     }
 }
 
+impl AsRef<[u8; 20]> for NodeId {
+    fn as_ref(&self) -> &[u8; 20] {
+        &self.inner
+    }
+}
+
 impl From<[u8; 20]> for NodeId {
     fn from(inner: [u8; 20]) -> Self {
         NodeId { inner }


### PR DESCRIPTION
Needed to easily convert `NodeId` into [`H160`](https://docs.rs/ethereum-types/0.12.1/ethereum_types/struct.H160.html#impl-From%3C%26%27a%20%5Bu8%3B%2020%5D%3E):

```rust
addr: H160 = node_id.as_ref().into()
```