### PR TITLE
Fix chrono::Date and MaybeUninit

### DIFF
--- a/model/src/node_id.rs
+++ b/model/src/node_id.rs
@@ -1,7 +1,6 @@
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 use std::borrow::Cow;
 use std::convert::TryFrom;
-use std::mem::MaybeUninit;
 use std::str::FromStr;
 use std::{fmt, str};
 
@@ -41,7 +40,7 @@ impl NodeId {
     where
         F: FnOnce(&str) -> R,
     {
-        let mut hex_str: [u8; 42] = unsafe { MaybeUninit::uninit().assume_init() };
+        let mut hex_str = [0u8; 42];
 
         hex_str[0] = '0' as u8;
         hex_str[1] = 'x' as u8;
@@ -215,7 +214,7 @@ impl<'de> de::Visitor<'de> for NodeIdVisit {
         E: de::Error,
     {
         if v.len() == NODE_ID_LENGTH {
-            let mut inner: [u8; NODE_ID_LENGTH] = unsafe { MaybeUninit::uninit().assume_init() };
+            let mut inner = [0u8; NODE_ID_LENGTH];
             inner.copy_from_slice(v);
             Ok(NodeId { inner })
         } else {

--- a/src/market/provider.rs
+++ b/src/market/provider.rs
@@ -1,6 +1,3 @@
-// TODO: https://github.com/golemfactory/ya-client/issues/132
-#![allow(deprecated)]
-
 //! Provider part of the Market API
 use ya_client_model::market::{
     agreement::State, Agreement, AgreementListEntry, AgreementOperationEvent, NewOffer,
@@ -8,7 +5,7 @@ use ya_client_model::market::{
 };
 
 use crate::{web::default_on_timeout, web::WebClient, web::WebInterface, Result};
-use chrono::{Date, DateTime, TimeZone, Utc};
+use chrono::{DateTime, TimeZone, Utc};
 use std::fmt::Display;
 
 /// Bindings for Provider part of the Market API.
@@ -223,8 +220,8 @@ impl MarketProviderApi {
     pub async fn list_agreements(
         &self,
         state: Option<State>,
-        before_date: Option<Date<Utc>>,
-        after_date: Option<Date<Utc>>,
+        before_date: Option<DateTime<Utc>>,
+        after_date: Option<DateTime<Utc>>,
         app_session_id: Option<String>,
     ) -> Result<Vec<AgreementListEntry>> {
         let url = url_format!(

--- a/src/market/requestor.rs
+++ b/src/market/requestor.rs
@@ -1,6 +1,3 @@
-// TODO: https://github.com/golemfactory/ya-client/issues/132
-#![allow(deprecated)]
-
 //! Requestor part of the Market API
 use ya_client_model::market::{
     agreement::State, Agreement, AgreementListEntry, AgreementOperationEvent, AgreementProposal,
@@ -8,7 +5,7 @@ use ya_client_model::market::{
 };
 
 use crate::{web::default_on_timeout, web::WebClient, web::WebInterface, Result};
-use chrono::{Date, DateTime, TimeZone, Utc};
+use chrono::{DateTime, TimeZone, Utc};
 use std::fmt::Display;
 
 /// Bindings for Requestor part of the Market API.
@@ -171,8 +168,8 @@ impl MarketRequestorApi {
     pub async fn list_agreements(
         &self,
         state: Option<State>,
-        before_date: Option<Date<Utc>>,
-        after_date: Option<Date<Utc>>,
+        before_date: Option<DateTime<Utc>>,
+        after_date: Option<DateTime<Utc>>,
         app_session_id: Option<String>,
     ) -> Result<Vec<AgreementListEntry>> {
         let url = url_format!(


### PR DESCRIPTION
`chrono::Date` is now deprecated and there was an unsound `MaybeUninit` use, which rustc now warns about.