### PR TITLE
Fix `url_format`

### DIFF
--- a/src/activity/provider.rs
+++ b/src/activity/provider.rs
@@ -28,19 +28,19 @@ impl ActivityProviderApi {
 
     /// Fetch activity state (which may include error details)
     pub async fn get_activity_state(&self, activity_id: &str) -> Result<ActivityState> {
-        let uri = url_format!("activity/{activity_id}/state", activity_id);
+        let uri = url_format!("activity/{activity_id}/state");
         self.client.get(&uri).send().json().await
     }
 
     /// Set state of specified Activity.
     pub async fn set_activity_state(&self, activity_id: &str, state: &ActivityState) -> Result<()> {
-        let uri = url_format!("activity/{activity_id}/state", activity_id);
+        let uri = url_format!("activity/{activity_id}/state");
         self.client.put(&uri).send_json(&state).json().await
     }
 
     /// Fetch current activity usage (which may include error details)
     pub async fn get_activity_usage(&self, activity_id: &str) -> Result<ActivityUsage> {
-        let uri = url_format!("activity/{activity_id}/usage", activity_id);
+        let uri = url_format!("activity/{activity_id}/usage");
         self.client.get(&uri).send().json().await
     }
 

--- a/src/activity/requestor/control.rs
+++ b/src/activity/requestor/control.rs
@@ -68,14 +68,14 @@ impl ActivityRequestorControlApi {
 
     /// Destroys given Activity.
     pub async fn destroy_activity(&self, activity_id: &str) -> Result<()> {
-        let uri = url_format!("activity/{activity_id}", activity_id);
+        let uri = url_format!("activity/{activity_id}");
         self.client.delete(&uri).send().json().await?;
         Ok(())
     }
 
     /// Executes an ExeScript batch within a given Activity.
     pub async fn exec(&self, script: ExeScriptRequest, activity_id: &str) -> Result<String> {
-        let uri = url_format!("activity/{activity_id}/exec", activity_id);
+        let uri = url_format!("activity/{activity_id}/exec");
         self.client.post(&uri).send_json(&script).json().await
     }
 
@@ -90,8 +90,6 @@ impl ActivityRequestorControlApi {
     ) -> Result<Vec<ExeScriptCommandResult>> {
         let uri = url_format!(
             "activity/{activity_id}/exec/{batch_id}",
-            activity_id,
-            batch_id,
             #[query] timeout,
             #[query] command_index,
         );
@@ -104,11 +102,7 @@ impl ActivityRequestorControlApi {
         activity_id: &str,
         batch_id: &str,
     ) -> Result<impl Stream<Item = RuntimeEvent>> {
-        let uri = url_format!(
-            "activity/{activity_id}/exec/{batch_id}",
-            activity_id,
-            batch_id,
-        );
+        let uri = url_format!("activity/{activity_id}/exec/{batch_id}",);
         let stream = self
             .client
             .event_stream(&uri)

--- a/src/activity/requestor/state.rs
+++ b/src/activity/requestor/state.rs
@@ -23,19 +23,19 @@ impl WebInterface for ActivityRequestorStateApi {
 impl ActivityRequestorStateApi {
     /// Get running command for a specified Activity.
     pub async fn get_running_command(&self, activity_id: &str) -> Result<ExeScriptCommandState> {
-        let uri = url_format!("activity/{activity_id}/command", activity_id);
+        let uri = url_format!("activity/{activity_id}/command");
         self.client.get(&uri).send().json().await
     }
 
     /// Get state of specified Activity.
     pub async fn get_state(&self, activity_id: &str) -> Result<ActivityState> {
-        let uri = url_format!("activity/{activity_id}/state", activity_id);
+        let uri = url_format!("activity/{activity_id}/state");
         self.client.get(&uri).send().json().await
     }
 
     /// Get usage of specified Activity.
     pub async fn get_usage(&self, activity_id: &str) -> Result<ActivityUsage> {
-        let uri = url_format!("activity/{activity_id}/usage", activity_id);
+        let uri = url_format!("activity/{activity_id}/usage");
         self.client.get(&uri).send().json().await
     }
 }

--- a/src/market/provider.rs
+++ b/src/market/provider.rs
@@ -42,7 +42,7 @@ impl MarketProviderApi {
     /// This implies, that client code should not `unsubscribe_offer` before it has received
     /// all expected/useful inputs from `collect_demands`.
     pub async fn unsubscribe(&self, subscription_id: &str) -> Result<()> {
-        let url = url_format!("offers/{subscription_id}", subscription_id);
+        let url = url_format!("offers/{subscription_id}");
         self.client.delete(&url).send().json().await
     }
 
@@ -84,7 +84,6 @@ impl MarketProviderApi {
     ) -> Result<Vec<ProviderEvent>> {
         let url = url_format!(
             "offers/{subscription_id}/events",
-            subscription_id,
             #[query] timeout,
             #[query] max_events,
         );
@@ -94,11 +93,7 @@ impl MarketProviderApi {
 
     /// Fetches Proposal (Demand) with given id.
     pub async fn get_proposal(&self, subscription_id: &str, proposal_id: &str) -> Result<Proposal> {
-        let url = url_format!(
-            "offers/{subscription_id}/proposals/{proposal_id}",
-            subscription_id,
-            proposal_id,
-        );
+        let url = url_format!("offers/{subscription_id}/proposals/{proposal_id}",);
         self.client.get(&url).send().json().await
     }
 
@@ -112,11 +107,7 @@ impl MarketProviderApi {
         proposal_id: &str,
         reason: &Option<Reason>,
     ) -> Result<()> {
-        let url = url_format!(
-            "offers/{subscription_id}/proposals/{proposal_id}/reject",
-            subscription_id,
-            proposal_id,
-        );
+        let url = url_format!("offers/{subscription_id}/proposals/{proposal_id}/reject",);
         self.client.post(&url).send_json(&reason).json().await
     }
 
@@ -130,11 +121,7 @@ impl MarketProviderApi {
         subscription_id: &str,
         proposal_id: &str,
     ) -> Result<String> {
-        let url = url_format!(
-            "offers/{subscription_id}/proposals/{proposal_id}",
-            subscription_id,
-            proposal_id,
-        );
+        let url = url_format!("offers/{subscription_id}/proposals/{proposal_id}",);
         self.client
             .post(&url)
             .send_json(&offer_proposal)
@@ -179,7 +166,6 @@ impl MarketProviderApi {
     ) -> Result<()> {
         let url = url_format!(
             "agreements/{agreement_id}/approve",
-            agreement_id,
             #[query] app_session_id,
             #[query] timeout,
         );
@@ -197,7 +183,7 @@ impl MarketProviderApi {
         agreement_id: &str,
         reason: &Option<Reason>,
     ) -> Result<()> {
-        let url = url_format!("agreements/{agreement_id}/reject", agreement_id);
+        let url = url_format!("agreements/{agreement_id}/reject");
         self.client.post(&url).send_json(&reason).json().await
     }
 
@@ -207,7 +193,7 @@ impl MarketProviderApi {
         agreement_id: &str,
         reason: &Option<Reason>,
     ) -> Result<()> {
-        let url = url_format!("agreements/{agreement_id}/terminate", agreement_id);
+        let url = url_format!("agreements/{agreement_id}/terminate");
         self.client.post(&url).send_json(&reason).json().await
     }
 
@@ -240,7 +226,7 @@ impl MarketProviderApi {
 
     /// Fetches agreement with given agreement id.
     pub async fn get_agreement(&self, agreement_id: &str) -> Result<Agreement> {
-        let url = url_format!("agreements/{agreement_id}", agreement_id);
+        let url = url_format!("agreements/{agreement_id}");
         self.client.get(&url).send().json().await
     }
 

--- a/src/market/requestor.rs
+++ b/src/market/requestor.rs
@@ -43,7 +43,7 @@ impl MarketRequestorApi {
 
     /// Stop subscription by invalidating a previously published Demand.
     pub async fn unsubscribe(&self, subscription_id: &str) -> Result<()> {
-        let url = url_format!("demands/{subscription_id}", subscription_id);
+        let url = url_format!("demands/{subscription_id}");
         self.client.delete(&url).send().json().await
     }
 
@@ -82,7 +82,6 @@ impl MarketRequestorApi {
     ) -> Result<Vec<RequestorEvent>> {
         let url = url_format!(
             "demands/{subscription_id}/events",
-            subscription_id,
             #[query] timeout,
             #[query] max_events,
         );
@@ -96,11 +95,7 @@ impl MarketRequestorApi {
         subscription_id: &str,
         proposal_id: &str,
     ) -> Result<String> {
-        let url = url_format!(
-            "demands/{subscription_id}/proposals/{proposal_id}",
-            subscription_id,
-            proposal_id,
-        );
+        let url = url_format!("demands/{subscription_id}/proposals/{proposal_id}",);
         self.client
             .post(&url)
             .send_json(&demand_proposal)
@@ -110,11 +105,7 @@ impl MarketRequestorApi {
 
     /// Fetches Proposal (Offer) with given id.
     pub async fn get_proposal(&self, subscription_id: &str, proposal_id: &str) -> Result<Proposal> {
-        let url = url_format!(
-            "demands/{subscription_id}/proposals/{proposal_id}",
-            subscription_id,
-            proposal_id,
-        );
+        let url = url_format!("demands/{subscription_id}/proposals/{proposal_id}",);
         self.client.get(&url).send().json().await
     }
 
@@ -128,11 +119,7 @@ impl MarketRequestorApi {
         proposal_id: &str,
         reason: &Option<Reason>,
     ) -> Result<()> {
-        let url = url_format!(
-            "demands/{subscription_id}/proposals/{proposal_id}/reject",
-            subscription_id,
-            proposal_id,
-        );
+        let url = url_format!("demands/{subscription_id}/proposals/{proposal_id}/reject",);
         self.client.post(&url).send_json(&reason).json().await
     }
 
@@ -188,7 +175,7 @@ impl MarketRequestorApi {
 
     /// Fetches agreement with given agreement id.
     pub async fn get_agreement(&self, agreement_id: &str) -> Result<Agreement> {
-        let url = url_format!("agreements/{agreement_id}", agreement_id);
+        let url = url_format!("agreements/{agreement_id}");
         self.client.get(&url).send().json().await
     }
 
@@ -202,7 +189,6 @@ impl MarketRequestorApi {
     ) -> Result<()> {
         let url = url_format!(
             "agreements/{agreement_id}/confirm",
-            agreement_id,
             #[query] app_session_id,
         );
         self.client.post(&url).send().json().await
@@ -245,7 +231,6 @@ impl MarketRequestorApi {
     ) -> Result<()> {
         let url = url_format!(
             "agreements/{agreement_id}/wait",
-            agreement_id,
             #[query] timeout,
         );
         self.client.post(&url).send().json().await
@@ -263,7 +248,7 @@ impl MarketRequestorApi {
         agreement_id: &str,
         reason: &Option<Reason>,
     ) -> Result<()> {
-        let url = url_format!("agreements/{agreement_id}/cancel", agreement_id);
+        let url = url_format!("agreements/{agreement_id}/cancel");
         self.client.post(&url).send_json(&reason).json().await
     }
 
@@ -273,7 +258,7 @@ impl MarketRequestorApi {
         agreement_id: &str,
         reason: &Option<Reason>,
     ) -> Result<()> {
-        let url = url_format!("agreements/{agreement_id}/terminate", agreement_id);
+        let url = url_format!("agreements/{agreement_id}/terminate");
         self.client.post(&url).send_json(&reason).json().await
     }
 

--- a/src/net.rs
+++ b/src/net.rs
@@ -65,49 +65,49 @@ impl NetVpnApi {
 
     /// Retrieves a requestor's virtual private network.
     pub async fn get_network(&self, network_id: &str) -> Result<Network> {
-        let url = url_format!("net/{network_id}", network_id);
+        let url = url_format!("net/{network_id}");
         self.client.get(&url).send().json().await
     }
 
     /// Unregisters an existing virtual private network overlay on the network.
     pub async fn remove_network(&self, network_id: &str) -> Result<()> {
-        let url = url_format!("net/{network_id}", network_id);
+        let url = url_format!("net/{network_id}");
         self.client.delete(&url).send().json().await
     }
 
     /// Retrieves requestor's addresses in a virtual private network.
     pub async fn get_addresses(&self, network_id: &str) -> Result<Vec<Address>> {
-        let url = url_format!("net/{network_id}/addresses", network_id);
+        let url = url_format!("net/{network_id}/addresses");
         self.client.get(&url).send().json().await
     }
 
     /// Assigns a new address of the requestor in an existing private network.
     pub async fn add_address(&self, network_id: &str, address: &Address) -> Result<()> {
-        let url = url_format!("net/{network_id}/addresses", network_id);
+        let url = url_format!("net/{network_id}/addresses");
         self.client.post(&url).send_json(&address).json().await
     }
 
     /// Retrieves nodes within a virtual private network.
     pub async fn get_nodes(&self, network_id: &str) -> Result<Vec<Node>> {
-        let url = url_format!("net/{network_id}/nodes", network_id);
+        let url = url_format!("net/{network_id}/nodes");
         self.client.get(&url).send().json().await
     }
 
     /// Registers a node in a virtual private network.
     pub async fn add_node(&self, network_id: &str, node: &Node) -> Result<()> {
-        let url = url_format!("net/{network_id}/nodes", network_id);
+        let url = url_format!("net/{network_id}/nodes");
         self.client.post(&url).send_json(&node).json().await
     }
 
     /// Unregisters an existing node in a virtual private network.
     pub async fn remove_node(&self, network_id: &str, node_id: &str) -> Result<()> {
-        let url = url_format!("net/{network_id}/nodes/{node_id}", network_id, node_id);
+        let url = url_format!("net/{network_id}/nodes/{node_id}");
         self.client.post(&url).send().json().await
     }
 
     /// Lists TCP connections
     pub async fn list_tcp(&self, network_id: &str) -> Result<Vec<Connection>> {
-        let url = url_format!("net/{network_id}/tcp", network_id);
+        let url = url_format!("net/{network_id}/tcp");
         self.client.get(&url).send().json().await
     }
 
@@ -118,7 +118,7 @@ impl NetVpnApi {
         ip: &str,
         port: u16,
     ) -> Result<Framed<BoxedSocket, Codec>> {
-        let url = url_format!("net/{network_id}/tcp/{ip}/{port}", network_id, ip, port);
+        let url = url_format!("net/{network_id}/tcp/{ip}/{port}");
         let (mut res, conn) = self.client.ws(&url).await?;
 
         let status = res.status();

--- a/src/payment/api.rs
+++ b/src/payment/api.rs
@@ -98,18 +98,18 @@ impl PaymentApi {
     }
 
     pub async fn get_allocation(&self, allocation_id: &str) -> Result<Allocation> {
-        let url = url_format!("allocations/{allocation_id}", allocation_id);
+        let url = url_format!("allocations/{allocation_id}");
         self.client.get(&url).send().json().await
     }
 
     pub async fn amend_allocation(&self, allocation: &Allocation) -> Result<Allocation> {
         let allocation_id = &allocation.allocation_id;
-        let url = url_format!("allocations/{allocation_id}", allocation_id);
+        let url = url_format!("allocations/{allocation_id}");
         self.client.put(&url).send_json(allocation).json().await
     }
 
     pub async fn release_allocation(&self, allocation_id: &str) -> Result<()> {
-        let url = url_format!("allocations/{allocation_id}", allocation_id);
+        let url = url_format!("allocations/{allocation_id}");
         self.client.delete(&url).send().json().await
     }
 
@@ -148,7 +148,7 @@ impl PaymentApi {
     }
 
     pub async fn get_debit_note(&self, debit_note_id: &str) -> Result<DebitNote> {
-        let url = url_format!("debitNotes/{debit_note_id}", debit_note_id);
+        let url = url_format!("debitNotes/{debit_note_id}");
         self.client.get(&url).send().json().await
     }
 
@@ -277,7 +277,7 @@ impl PaymentApi {
     }
 
     pub async fn get_invoice(&self, invoice_id: &str) -> Result<Invoice> {
-        let url = url_format!("invoices/{invoice_id}", invoice_id);
+        let url = url_format!("invoices/{invoice_id}");
         self.client.get(&url).send().json().await
     }
 
@@ -403,7 +403,7 @@ impl PaymentApi {
     }
 
     pub async fn get_payment(&self, payment_id: &str) -> Result<Payment> {
-        let url = url_format!("payments/{payment_id}", payment_id);
+        let url = url_format!("payments/{payment_id}");
         self.client.get(&url).send().json().await
     }
 }


### PR DESCRIPTION
Rust emitted warnings due to the macro expanding as `format!("{}",foo=foo)` when invoked as `url_format("{}",foo)`.

As the intended usage was `url_format("{foo}",foo)` anyway, the recent changes to the format macro allow for a far more ergonomic notation, that being `url_format("{foo}")`. This patch changes the macro to remove expansion of all arguments to named ones, and clearly documents its behavior.