### PR TITLE
Enable amending allocations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,14 +12,18 @@ edition = "2021"
 default = []
 cli = ['structopt']
 sgx = [
-    'graphene-sgx', 'lazy_static', 'secp256k1',
-    'openssl', 'secp256k1/serde', 'secp256k1/rand',
-    'ya-client-model/sgx', 'rand']
+    'graphene-sgx',
+    'lazy_static',
+    'secp256k1',
+    'openssl',
+    'secp256k1/serde',
+    'secp256k1/rand',
+    'ya-client-model/sgx',
+    'rand',
+]
 
 [workspace]
-members = [
-    "model",
-]
+members = ["model"]
 
 [workspace.dependencies]
 secp256k1 = ">=0.23,<0.28"
@@ -44,7 +48,7 @@ url = "2"
 
 graphene-sgx = { version = "0.3.3", optional = true }
 lazy_static = { version = "1.4", optional = true }
-secp256k1 = { workspace=true, optional = true }
+secp256k1 = { workspace = true, optional = true }
 rand = { version = "0.8.5", optional = true }
 structopt = { version = "0.3", optional = true }
 openssl = { version = "0.10", optional = true }
@@ -52,6 +56,7 @@ openssl = { version = "0.10", optional = true }
 [dev-dependencies]
 actix-rt = "2.7.0"
 anyhow = "1.0"
+bigdecimal = { version = "0.2" }
 env_logger = "0.10"
 structopt = "0.3"
 

--- a/examples/allocation_management.rs
+++ b/examples/allocation_management.rs
@@ -1,0 +1,107 @@
+use std::{env, str::FromStr};
+
+use bigdecimal::BigDecimal;
+use chrono::{DateTime, Utc};
+use structopt::StructOpt;
+use url::Url;
+use ya_client::{
+    payment::PaymentApi,
+    web::{WebClient, WebInterface},
+    Result,
+};
+use ya_client_model::payment::{Allocation, NewAllocation};
+
+#[derive(Clone, StructOpt)]
+#[structopt(name = "Market", about = "Market service properties")]
+struct Options {
+    #[structopt(short, long, default_value = <PaymentApi as WebInterface>::API_URL_ENV_VAR )]
+    url: Url,
+    #[structopt(long)]
+    app_key: String,
+    #[structopt(long, default_value = "info")]
+    log_level: String,
+    #[structopt(subcommand)]
+    command: Command,
+}
+
+#[derive(Clone, StructOpt)]
+enum Command {
+    List,
+    Get {
+        #[structopt(long)]
+        id: String,
+    },
+    Amend {
+        #[structopt(long)]
+        id: String,
+        #[structopt(long)]
+        budget: String,
+    },
+    Create {
+        #[structopt(long)]
+        budget: String,
+        #[structopt(long, default_value = "erc20-goerli-tglm")]
+        platform: String,
+    },
+}
+
+fn print_allocations<'a>(allocations: impl IntoIterator<Item = &'a Allocation>) {
+    let s = " ".repeat(10);
+    println!("{s} allocation - id {s}| total amount");
+    println!("{}+{}", "-".repeat(17 + 2 * 10), "-".repeat(14));
+    for allocation in allocations {
+        println!("{} | {}", allocation.allocation_id, allocation.total_amount);
+    }
+}
+
+#[actix_rt::main]
+async fn main() -> Result<()> {
+    let options = Options::from_args();
+    println!("\nrun this example with RUST_LOG=debug to see REST calls\n");
+    env::set_var(
+        "RUST_LOG",
+        env::var("RUST_LOG").unwrap_or(options.log_level.clone()),
+    );
+    env_logger::init();
+
+    let client: PaymentApi = WebClient::with_token(&options.app_key).interface_at(options.url)?;
+
+    match options.command {
+        Command::List => {
+            let allocations = client
+                .get_allocations(Option::<DateTime<Utc>>::None, None)
+                .await?;
+            print_allocations(&allocations);
+        }
+        Command::Get { id } => {
+            let allocation = client.get_allocation(&id).await?;
+            println!("{:#?}", allocation);
+        }
+        Command::Amend { id, budget } => {
+            let new_allocation = NewAllocation {
+                total_amount: BigDecimal::from_str(&budget).unwrap(),
+                make_deposit: true,
+                address: None,
+                payment_platform: None,
+                timeout: None,
+            };
+
+            let allocation = client.amend_allocation(&id, &new_allocation).await?;
+            println!("{:#?}", allocation);
+        }
+        Command::Create { budget, platform } => {
+            let allocation = client
+                .create_allocation(&NewAllocation {
+                    total_amount: BigDecimal::from_str(&budget).unwrap(),
+                    make_deposit: true,
+                    address: None,
+                    payment_platform: Some(platform),
+                    timeout: None,
+                })
+                .await?;
+            println!("{:#?}", allocation);
+        }
+    }
+
+    Ok(())
+}

--- a/src/payment/api.rs
+++ b/src/payment/api.rs
@@ -105,8 +105,11 @@ impl PaymentApi {
         self.client.get(&url).send().json().await
     }
 
-    pub async fn amend_allocation(&self, allocation: &Allocation) -> Result<Allocation> {
-        let allocation_id = &allocation.allocation_id;
+    pub async fn amend_allocation(
+        &self,
+        allocation_id: &str,
+        allocation: &NewAllocation,
+    ) -> Result<Allocation> {
         let url = url_format!("allocations/{allocation_id}");
         self.client.put(&url).send_json(allocation).json().await
     }


### PR DESCRIPTION
* The signature of the `amend_allocation` function was wrong -- it should take `NewAllocation` as an argument, which comprises of the read-write fields of the `Allocation` as per the OpenAPI spec.
* Added `allocation_management` example