### PR TITLE
Enable amending allocations

### DIFF
--- a/examples/allocation_management.rs
+++ b/examples/allocation_management.rs
@@ -9,7 +9,7 @@ use ya_client::{
     web::{WebClient, WebInterface},
     Result,
 };
-use ya_client_model::payment::{Allocation, NewAllocation};
+use ya_client_model::payment::{Allocation, AllocationUpdate, NewAllocation};
 
 #[derive(Clone, StructOpt)]
 #[structopt(name = "Market", about = "Market service properties")]
@@ -78,11 +78,8 @@ async fn main() -> Result<()> {
             println!("{:#?}", allocation);
         }
         Command::Amend { id, budget } => {
-            let new_allocation = NewAllocation {
-                total_amount: BigDecimal::from_str(&budget).unwrap(),
-                make_deposit: true,
-                address: None,
-                payment_platform: None,
+            let new_allocation = AllocationUpdate {
+                total_amount: Some(BigDecimal::from_str(&budget).unwrap()),
                 timeout: None,
             };
 

--- a/model/src/payment.rs
+++ b/model/src/payment.rs
@@ -22,6 +22,7 @@ pub use self::account::Account;
 pub use self::activity_payment::ActivityPayment;
 pub use self::agreement_payment::AgreementPayment;
 pub use self::allocation::Allocation;
+pub use self::allocation::AllocationUpdate;
 pub use self::allocation::NewAllocation;
 pub use self::debit_note::DebitNote;
 pub use self::debit_note::NewDebitNote;

--- a/model/src/payment/allocation.rs
+++ b/model/src/payment/allocation.rs
@@ -27,3 +27,12 @@ pub struct NewAllocation {
     pub timeout: Option<DateTime<Utc>>,
     pub make_deposit: bool,
 }
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AllocationUpdate {
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub total_amount: Option<BigDecimal>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub timeout: Option<DateTime<Utc>>,
+}

--- a/specs/payment-api.yaml
+++ b/specs/payment-api.yaml
@@ -603,13 +603,11 @@ paths:
       tags:
         - requestor
       summary: Amend Allocation.
-      description: >
-        **WARNING:** Operation not implemented.
       operationId: amendAllocation
       parameters:
         - $ref: '#/components/parameters/allocationId'
       requestBody:
-        $ref: '#/components/requestBodies/Allocation'
+        $ref: '#/components/requestBodies/AllocationUpdate'
       responses:
         200:
           $ref: '#/components/responses/Allocation'
@@ -790,6 +788,13 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/Allocation'
+
+    AllocationUpdate:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/AllocationUpdate'
 
     Acceptance:
       required: true
@@ -1175,6 +1180,18 @@ components:
         - remainingAmount
         - timestamp
         - makeDeposit
+
+    AllocationUpdate:
+      type: object
+      description: >
+        AllocationUpdate represents the changes that can be made to an existing
+        allocation.
+      properties:
+        totalAmount:
+          type: string
+        timeout:
+          type: string
+          format: date-time
 
     Payment:
       type: object

--- a/src/payment/api.rs
+++ b/src/payment/api.rs
@@ -108,7 +108,7 @@ impl PaymentApi {
     pub async fn amend_allocation(
         &self,
         allocation_id: &str,
-        allocation: &NewAllocation,
+        allocation: &AllocationUpdate,
     ) -> Result<Allocation> {
         let url = url_format!("allocations/{allocation_id}");
         self.client.put(&url).send_json(allocation).json().await


### PR DESCRIPTION
spec:
* Add AllocationUpdate schema which only contains fields of Allocation that can be modified.
* Change spec so that the allocation put takes AllocationUpdate.

Rust implementation:
* Modify allocation to match the new spec.
* Added allocation_management example.