### PR TITLE
Add identity and version api spec files

### DIFF
--- a/specs/identity-api.yaml
+++ b/specs/identity-api.yaml
@@ -1,0 +1,49 @@
+openapi: 3.0.2
+info:
+  version: 0.1.0
+  title: Yagna Identity API
+  description: Yagna Identity API
+security:
+  - app_key: []
+paths:
+  /me:
+    get:
+      operationId: getIdentity
+      summary: GetIdentity - Fetches the identity of the user.
+      responses:
+        '200':
+          $ref: '#/components/responses/Identity'
+        '400':
+          $ref: 'common.yaml#/responses/BadRequest'
+        '401':
+          $ref: 'common.yaml#/responses/Unauthorized'
+        default:
+          $ref: 'common.yaml#/responses/UnexpectedError'
+components:
+  securitySchemes:
+    app_key:
+      $ref: 'common.yaml#/components/securitySchemes/app_key'
+  responses:
+    Identity:
+      description: Identity
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Identity'
+  schemas:
+    Identity:
+      type: object
+      properties:
+        identity:
+          type: string
+          description: Address
+        name:
+          type: string
+          description: Name
+        role:
+          type: string
+          description: Role
+      required:
+        - identity
+        - name
+        - role

--- a/specs/version-api.yaml
+++ b/specs/version-api.yaml
@@ -31,10 +31,10 @@ components:
       properties:
         version:
           type: string
-          example: 0.13.2
+          example: 0.12.1
         name:
           type: string
-          example: v0.13.2
+          example: v0.12.1 Aware Thrill
         seen:
           type: boolean
         releaseTs:
@@ -49,17 +49,13 @@ components:
         - name
         - seen
         - releaseTs
-        - insertionTs
-        - updateTs
+
     YagnaVersionResponse:
       type: object
       properties:
         current:
           $ref: '#/components/schemas/YagnaVersionInfo'
         pending:
-          nullable: true
-          allOf:
-            - $ref: '#/components/schemas/YagnaVersionInfo'
+          $ref: '#/components/schemas/YagnaVersionInfo'
       required:
         - current
-        - pending

--- a/specs/version-api.yaml
+++ b/specs/version-api.yaml
@@ -1,0 +1,65 @@
+openapi: 3.0.2
+info:
+  version: 0.1.0
+  title: Yagna Version API
+  description: Yagna Version API
+paths:
+  /version/get:
+    get:
+      operationId: getVersion
+      summary: GetVersion - Fetches the version of Yagna
+      responses:
+        '200':
+          $ref: '#/components/responses/Version'
+        '400':
+          $ref: 'common.yaml#/responses/BadRequest'
+        '401':
+          $ref: 'common.yaml#/responses/Unauthorized'
+        default:
+          $ref: 'common.yaml#/responses/UnexpectedError'
+components:
+  responses:
+    Version:
+      description: Yagna Version Response
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/YagnaVersionResponse'
+  schemas:
+    YagnaVersionInfo:
+      type: object
+      properties:
+        version:
+          type: string
+          example: 0.13.2
+        name:
+          type: string
+          example: v0.13.2
+        seen:
+          type: boolean
+        releaseTs:
+          type: string
+          example: '2023-12-07T14:23:48'
+        insertionTs:
+          type: string
+        updateTs:
+          type: string
+      required:
+        - version
+        - name
+        - seen
+        - releaseTs
+        - insertionTs
+        - updateTs
+    YagnaVersionResponse:
+      type: object
+      properties:
+        current:
+          $ref: '#/components/schemas/YagnaVersionInfo'
+        pending:
+          nullable: true
+          allOf:
+            - $ref: '#/components/schemas/YagnaVersionInfo'
+      required:
+        - current
+        - pending


### PR DESCRIPTION
`/me` and `/version/get` are already implemented in yagna but are not defined here. In golem-js we pull specs from this repo to auto-generate our http client. Right now, we have to manually add these two endpoints on top of the generated code.