### PR TITLE
Correct the types on event returning endpoints for better client-generated typics

### DIFF
--- a/specs/market-api.yaml
+++ b/specs/market-api.yaml
@@ -1065,13 +1065,7 @@ components:
           schema:
             type: array
             items:
-              anyOf:
-                - $ref: "#/components/schemas/AgreementApprovedEvent"
-                - $ref: "#/components/schemas/AgreementTerminatedEvent"
-                - $ref: "#/components/schemas/AgreementCancelledEvent"
-                - $ref: "#/components/schemas/AgreementRejectedEvent"
-              discriminator:
-                propertyName: eventType
+              $ref: '#/components/schemas/AgreementOperationEvent'
 
     AgreementList:
       description: Result of listing agreements.
@@ -1371,8 +1365,6 @@ components:
         role:
           type: string
 
-    # note this should be specified as a sub-class of Event, BUT
-    # a number of OpenAPI code generators fail on multistory inheritance hierarchies :(
     AgreementOperationEvent:
       allOf:
         - $ref: '#/components/schemas/Event'

--- a/specs/market-api.yaml
+++ b/specs/market-api.yaml
@@ -31,7 +31,7 @@ servers:
   - url: /market-api/v1
 
 security:
-  - app_key: []
+  - app_key: [ ]
 
 tags:
   - name: requestor
@@ -1065,7 +1065,13 @@ components:
           schema:
             type: array
             items:
-              $ref: '#/components/schemas/AgreementEvent'
+              anyOf:
+                - $ref: "#/components/schemas/AgreementApprovedEvent"
+                - $ref: "#/components/schemas/AgreementTerminatedEvent"
+                - $ref: "#/components/schemas/AgreementCancelledEvent"
+                - $ref: "#/components/schemas/AgreementRejectedEvent"
+              discriminator:
+                propertyName: eventType
 
     AgreementList:
       description: Result of listing agreements.
@@ -1186,7 +1192,7 @@ components:
             state:
               type: string
               readOnly: true
-              enum: [Initial, Draft, Rejected, Accepted, Expired]
+              enum: [ Initial, Draft, Rejected, Accepted, Expired ]
               description: >
                 * `Initial` - proposal arrived from the market as response
                 to subscription
@@ -1220,7 +1226,7 @@ components:
 
     AgreementState:
       type: string
-      enum: [Proposal, Pending, Cancelled, Rejected, Approved, Expired, Terminated]
+      enum: [ Proposal, Pending, Cancelled, Rejected, Approved, Expired, Terminated ]
       description: >
         * `Proposal` - newly created by a Requestor (draft based on Proposal)
 
@@ -1368,20 +1374,16 @@ components:
     # note this should be specified as a sub-class of Event, BUT
     # a number of OpenAPI code generators fail on multistory inheritance hierarchies :(
     AgreementOperationEvent:
-      type: object
-      required:
-        - eventType
-        - eventDate
-        - agreementId
-      discriminator:
-        propertyName: eventType
-      properties:
-        eventType:
-          type: string
-        eventDate:
-          $ref: 'common.yaml#/components/schemas/Timestamp'
-        agreementId:
-          type: string
+      allOf:
+        - $ref: '#/components/schemas/Event'
+        - type: object
+          required:
+            - agreementId
+          discriminator:
+            propertyName: eventType
+          properties:
+            agreementId:
+              type: string
 
     AgreementApprovedEvent:
       allOf:
@@ -1413,7 +1415,7 @@ components:
           properties:
             terminator:
               type: string
-              enum: [Requestor, Provider]
+              enum: [ Requestor, Provider ]
             signature:
               type: string
             reason:

--- a/specs/payment-api.yaml
+++ b/specs/payment-api.yaml
@@ -936,17 +936,7 @@ components:
           schema:
             type: array
             items:
-              anyOf:
-                - $ref: '#/components/schemas/DebitNoteReceivedEvent'
-                - $ref: '#/components/schemas/DebitNoteAcceptedEvent'
-                - $ref: '#/components/schemas/DebitNoteRejectedEvent'
-                - $ref: '#/components/schemas/DebitNoteFailedEvent'
-                - $ref: '#/components/schemas/DebitNoteSettledEvent'
-                - $ref: '#/components/schemas/DebitNoteCancelledEvent'
-                - $ref: '#/components/schemas/DebitNotePaymentStatusEvent'
-                - $ref: '#/components/schemas/DebitNotePaymentOkEvent'
-              discriminator:
-                propertyName: eventType
+              $ref: '#/components/schemas/DebitNoteEvent'
 
     InvoiceEventList:
       description: OK
@@ -955,17 +945,7 @@ components:
           schema:
             type: array
             items:
-              anyOf:
-                - $ref: '#/components/schemas/InvoiceReceivedEvent'
-                - $ref: '#/components/schemas/InvoiceAcceptedEvent'
-                - $ref: '#/components/schemas/InvoiceRejectedEvent'
-                - $ref: '#/components/schemas/InvoiceFailedEvent'
-                - $ref: '#/components/schemas/InvoiceSettledEvent'
-                - $ref: '#/components/schemas/InvoiceCancelledEvent'
-                - $ref: '#/components/schemas/InvoicePaymentStatusEvent'
-                - $ref: '#/components/schemas/InvoicePaymentOkEvent'
-              discriminator:
-                propertyName: eventType
+              $ref: '#/components/schemas/InvoiceEvent'
 
     AccountList:
       description: OK
@@ -1426,6 +1406,7 @@ components:
       required:
         - eventType
         - eventDate
+        - debitNoteId
       discriminator:
         propertyName: eventType
       properties:
@@ -1434,80 +1415,56 @@ components:
         eventDate:
           type: string
           format: date-time
+        debitNoteId:
+          type: string
 
     DebitNoteReceivedEvent:
       allOf:
         - $ref: '#/components/schemas/DebitNoteEvent'
-        - type: object
-          properties:
-            debitNoteId:
-              type: string
+
 
     DebitNoteAcceptedEvent:
       allOf:
         - $ref: '#/components/schemas/DebitNoteEvent'
-        - type: object
-          properties:
-            debitNoteId:
-              type: string
 
     DebitNoteRejectedEvent:
       allOf:
         - $ref: '#/components/schemas/DebitNoteEvent'
         - type: object
           properties:
-            debitNoteId:
-              type: string
             rejection:
               $ref: '#/components/schemas/Rejection'
 
     DebitNoteFailedEvent:
       allOf:
         - $ref: '#/components/schemas/DebitNoteEvent'
-        - type: object
-          properties:
-            debitNoteId:
-              type: string
 
     DebitNoteSettledEvent:
       allOf:
         - $ref: '#/components/schemas/DebitNoteEvent'
-        - type: object
-          properties:
-            debitNoteId:
-              type: string
 
     DebitNoteCancelledEvent:
       allOf:
         - $ref: '#/components/schemas/DebitNoteEvent'
-        - type: object
-          properties:
-            debitNoteId:
-              type: string
 
     DebitNotePaymentStatusEvent:
       allOf:
         - $ref: '#/components/schemas/DebitNoteEvent'
         - type: object
           properties:
-            debitNoteId:
-              type: string
             property:
               $ref: '#/components/schemas/DriverStatusProperty'
 
     DebitNotePaymentOkEvent:
       allOf:
         - $ref: '#/components/schemas/DebitNoteEvent'
-        - type: object
-          properties:
-            debitNoteId:
-              type: string
 
     InvoiceEvent:
       type: object
       required:
         - eventType
         - eventDate
+        - invoiceId
       discriminator:
         propertyName: eventType
       properties:
@@ -1516,74 +1473,49 @@ components:
         eventDate:
           type: string
           format: date-time
+        invoiceId:
+          type: string
 
     InvoiceReceivedEvent:
       allOf:
         - $ref: '#/components/schemas/InvoiceEvent'
-        - type: object
-          properties:
-            invoiceId:
-              type: string
+
 
     InvoiceAcceptedEvent:
       allOf:
         - $ref: '#/components/schemas/InvoiceEvent'
-        - type: object
-          properties:
-            invoiceId:
-              type: string
 
     InvoiceRejectedEvent:
       allOf:
         - $ref: '#/components/schemas/InvoiceEvent'
         - type: object
           properties:
-            invoiceId:
-              type: string
             rejection:
               $ref: '#/components/schemas/Rejection'
 
     InvoiceFailedEvent:
       allOf:
         - $ref: '#/components/schemas/InvoiceEvent'
-        - type: object
-          properties:
-            invoiceId:
-              type: string
 
     InvoiceSettledEvent:
       allOf:
         - $ref: '#/components/schemas/InvoiceEvent'
-        - type: object
-          properties:
-            invoiceId:
-              type: string
 
     InvoiceCancelledEvent:
       allOf:
         - $ref: '#/components/schemas/InvoiceEvent'
-        - type: object
-          properties:
-            invoiceId:
-              type: string
 
     InvoicePaymentStatusEvent:
       allOf:
         - $ref: '#/components/schemas/InvoiceEvent'
         - type: object
           properties:
-            invoiceId:
-              type: string
             property:
               $ref: '#/components/schemas/DriverStatusProperty'
 
     InvoicePaymentOkEvent:
       allOf:
         - $ref: '#/components/schemas/InvoiceEvent'
-        - type: object
-          properties:
-            invoiceId:
-              type: string
 
     Account:
       description: Payment account (wallet)

--- a/specs/payment-api.yaml
+++ b/specs/payment-api.yaml
@@ -936,7 +936,17 @@ components:
           schema:
             type: array
             items:
-              $ref: '#/components/schemas/DebitNoteEvent'
+              anyOf:
+                - $ref: '#/components/schemas/DebitNoteReceivedEvent'
+                - $ref: '#/components/schemas/DebitNoteAcceptedEvent'
+                - $ref: '#/components/schemas/DebitNoteRejectedEvent'
+                - $ref: '#/components/schemas/DebitNoteFailedEvent'
+                - $ref: '#/components/schemas/DebitNoteSettledEvent'
+                - $ref: '#/components/schemas/DebitNoteCancelledEvent'
+                - $ref: '#/components/schemas/DebitNotePaymentStatusEvent'
+                - $ref: '#/components/schemas/DebitNotePaymentOkEvent'
+              discriminator:
+                propertyName: eventType
 
     InvoiceEventList:
       description: OK
@@ -945,7 +955,17 @@ components:
           schema:
             type: array
             items:
-              $ref: '#/components/schemas/InvoiceEvent'
+              anyOf:
+                - $ref: '#/components/schemas/InvoiceReceivedEvent'
+                - $ref: '#/components/schemas/InvoiceAcceptedEvent'
+                - $ref: '#/components/schemas/InvoiceRejectedEvent'
+                - $ref: '#/components/schemas/InvoiceFailedEvent'
+                - $ref: '#/components/schemas/InvoiceSettledEvent'
+                - $ref: '#/components/schemas/InvoiceCancelledEvent'
+                - $ref: '#/components/schemas/InvoicePaymentStatusEvent'
+                - $ref: '#/components/schemas/InvoicePaymentOkEvent'
+              discriminator:
+                propertyName: eventType
 
     AccountList:
       description: OK


### PR DESCRIPTION
fix: types on invoice, debit note and agreement collection endpoitns to enumerate possible values and discriminate them

I intended to provide a more specific type information in the OAS. This helps us to build a slightly better ya-ts-client release.