### PR TITLE
Changes to api, separating get requests from post due to generators problem with understanding readOnly field

### DIFF
--- a/specs/payment-api.yaml
+++ b/specs/payment-api.yaml
@@ -1063,13 +1063,10 @@ components:
         paymentDueDate:
           type: string
           format: date-time
-        status:
-          $ref: '#/components/schemas/InvoiceStatus'
       required:
         - agreementId
         - amount
         - paymentDueDate
-        - status
 
     Invoice:
       description: >
@@ -1110,6 +1107,8 @@ components:
               type: string
               format: date-time
               readOnly: true
+            status:
+              $ref: '#/components/schemas/InvoiceStatus'
           required:
             - invoiceId
             - issuerId
@@ -1118,6 +1117,7 @@ components:
             - payerAddr
             - paymentPlatform
             - timestamp
+            - status
 
     InvoiceStatus:
       description: >

--- a/specs/payment-api.yaml
+++ b/specs/payment-api.yaml
@@ -1046,43 +1046,12 @@ components:
           - totalAmountDue
           - status
 
-    Invoice:
+    InvoiceWrite:
       description: >
-        An Invoice is an artifact issued by the Provider to the Requestor, in
-        the context of a specific Agreement. It indicates the total Amount owed
-        by the Requestor in this Agreement. No further Debit Notes shall be
-        issued after the Invoice is issued. The issue of Invoice signals the
-        Termination of the Agreement (if it hasn't been terminated already).
-        No Activity execution is allowed after the Invoice is issued.
-
-
-        **NOTE:** An invoice can be issued even before any Activity is started in
-        the context of an Agreement (eg. in one off, 'fire-and-forget' payment
-        regime).
+        Subset of invoice used for creating it. See `Invoice` for a complete
+        description.
       type: object
       properties:
-        invoiceId:
-          type: string
-          readOnly: true
-        issuerId:
-          type: string
-          readOnly: true
-        recipientId:
-          type: string
-          readOnly: true
-        payeeAddr:
-          type: string
-          readOnly: true
-        payerAddr:
-          type: string
-          readOnly: true
-        paymentPlatform:
-          type: string
-          readOnly: true
-        timestamp:
-          type: string
-          format: date-time
-          readOnly: true
         agreementId:
           type: string
         activityIds:
@@ -1096,19 +1065,59 @@ components:
           format: date-time
         status:
           $ref: '#/components/schemas/InvoiceStatus'
-
       required:
-        - invoiceId
-        - issuerId
-        - recipientId
-        - payeeAddr
-        - payerAddr
-        - paymentPlatform
-        - timestamp
         - agreementId
         - amount
         - paymentDueDate
         - status
+
+    Invoice:
+      description: >
+        An Invoice is an artifact issued by the Provider to the Requestor, in
+        the context of a specific Agreement. It indicates the total Amount owed
+        by the Requestor in this Agreement. No further Debit Notes shall be
+        issued after the Invoice is issued. The issue of Invoice signals the
+        Termination of the Agreement (if it hasn't been terminated already).
+        No Activity execution is allowed after the Invoice is issued.
+
+
+        **NOTE:** An invoice can be issued even before any Activity is started in
+        the context of an Agreement (eg. in one off, 'fire-and-forget' payment
+        regime).
+      allOf:
+        - $ref: '#/components/schemas/InvoiceWrite'
+        - type: object
+          properties:
+            invoiceId:
+              type: string
+              readOnly: true
+            issuerId:
+              type: string
+              readOnly: true
+            recipientId:
+              type: string
+              readOnly: true
+            payeeAddr:
+              type: string
+              readOnly: true
+            payerAddr:
+              type: string
+              readOnly: true
+            paymentPlatform:
+              type: string
+              readOnly: true
+            timestamp:
+              type: string
+              format: date-time
+              readOnly: true
+          required:
+            - invoiceId
+            - issuerId
+            - recipientId
+            - payeeAddr
+            - payerAddr
+            - paymentPlatform
+            - timestamp
 
     InvoiceStatus:
       description: >

--- a/specs/payment-api.yaml
+++ b/specs/payment-api.yaml
@@ -804,7 +804,7 @@ components:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/Invoice'
+            $ref: '#/components/schemas/InvoiceWrite'
 
     Allocation:
       required: true

--- a/specs/payment-api.yaml
+++ b/specs/payment-api.yaml
@@ -1217,6 +1217,7 @@ components:
           format: date-time
         makeDeposit:
           type: boolean
+          deprecated: true
         deposit:
           type: object
           properties:
@@ -1235,7 +1236,6 @@ components:
         - spentAmount
         - remainingAmount
         - timestamp
-        - makeDeposit
 
     AllocationUpdate:
       type: object

--- a/specs/payment-api.yaml
+++ b/specs/payment-api.yaml
@@ -797,7 +797,7 @@ components:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/DebitNote'
+            $ref: '#/components/schemas/DebitNoteWrite'
 
     Invoice:
       required: true
@@ -960,6 +960,29 @@ components:
             $ref: '#/components/schemas/MarketDecoration'
 
   schemas:
+    DebitNoteWrite:
+      description: >
+        Subset of debit-note used for creating it. See `DebitNote` for a complete
+        description.
+      type: object
+      properties:
+        activityId:
+          type: string
+        totalAmountDue:
+          type: string
+        usageCounterVector:
+          type: object
+        paymentDueDate:
+          type: string
+          format: date-time
+        status:
+          $ref: '#/components/schemas/InvoiceStatus'
+
+      required:
+        - activityId
+        - totalAmountDue
+        - status
+
     DebitNote:
       description: >
         A Debit Note is an artifact issued by the Provider to the Requestor,
@@ -978,47 +1001,38 @@ components:
         trigger payments, therefore payment amount for the newly received Debit
         Note is expected to be determined by difference of Total Payments for
         the Agreement vs Total Amount Due.
-      type: object
-      properties:
-        debitNoteId:
-          type: string
-          readOnly: true
-        issuerId:
-          type: string
-          readOnly: true
-        recipientId:
-          type: string
-          readOnly: true
-        payeeAddr:
-          type: string
-          readOnly: true
-        payerAddr:
-          type: string
-          readOnly: true
-        paymentPlatform:
-          type: string
-          readOnly: true
-        previousDebitNoteId:
-          type: string
-          readOnly: true
-        timestamp:
-          type: string
-          format: date-time
-          readOnly: true
-        agreementId:
-          type: string
-          readOnly: true
-        activityId:
-          type: string
-        totalAmountDue:
-          type: string
-        usageCounterVector:
-          type: object
-        paymentDueDate:
-          type: string
-          format: date-time
-        status:
-          $ref: '#/components/schemas/InvoiceStatus'
+      allOf:
+      - $ref: '#/components/schemas/DebitNoteWrite'
+      - type: object
+        properties:
+          debitNoteId:
+            type: string
+            readOnly: true
+          issuerId:
+            type: string
+            readOnly: true
+          recipientId:
+            type: string
+            readOnly: true
+          payeeAddr:
+            type: string
+            readOnly: true
+          payerAddr:
+            type: string
+            readOnly: true
+          paymentPlatform:
+            type: string
+            readOnly: true
+          previousDebitNoteId:
+            type: string
+            readOnly: true
+          timestamp:
+            type: string
+            format: date-time
+            readOnly: true
+          agreementId:
+            type: string
+            readOnly: true
 
       required:
         - debitNoteId

--- a/specs/payment-api.yaml
+++ b/specs/payment-api.yaml
@@ -811,7 +811,7 @@ components:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/Allocation'
+            $ref: '#/components/schemas/AllocationWrite'
 
     AllocationUpdate:
       required: true
@@ -1177,23 +1177,14 @@ components:
         token:
           type: string
 
-    Allocation:
+    AllocationWrite:
       type: object
       description: >
-        An Allocation is a designated sum of money reserved for the purpose of
-        making some particular payments. Allocations are currently purely virtual
-        objects. They exist only in Requestor's database. An Allocation is
-        connected to a payment account (wallet) specified by `address` and
-        `paymentPlatform` field. If these fields are not present the default
-        payment platform is used and the address is assumed to be identical to
-        the Requestor's Node ID.
+        Subset of allocation used for creating it. See `Allocation` for a complete
+        description.
 
-
-        **NOTE:** `timeout` and `makeDeposit` field are currently ignored.
+        **NOTE:** The `makeDeposit` field is deprecated and ignored.
       properties:
-        allocationId:
-          type: string
-          readOnly: true
         address:
           type: string
         paymentPlatform:
@@ -1202,22 +1193,9 @@ components:
             - type: string
         totalAmount:
           type: string
-        spentAmount:
-          type: string
-          readOnly: true
-        remainingAmount:
-          type: string
-          readOnly: true
-        timestamp:
-          type: string
-          format: date-time
-          readOnly: true
         timeout:
           type: string
           format: date-time
-        makeDeposit:
-          type: boolean
-          deprecated: true
         deposit:
           type: object
           properties:
@@ -1230,12 +1208,11 @@ components:
           required:
             - id
             - contract
+        makeDeposit:
+          type: boolean
+          deprecated: true
       required:
-        - allocationId
         - totalAmount
-        - spentAmount
-        - remainingAmount
-        - timestamp
 
     AllocationUpdate:
       type: object
@@ -1248,6 +1225,41 @@ components:
         timeout:
           type: string
           format: date-time
+
+    Allocation:
+      allOf:
+        - $ref: '#/components/schemas/Allocation'
+        - type: object
+          description: >
+            An Allocation is a designated sum of money reserved for the purpose of
+            making some particular payments. Allocations are currently purely virtual
+            objects. They exist only in Requestor's database. An Allocation is
+            connected to a payment account (wallet) specified by `address` and
+            `paymentPlatform` field. If these fields are not present the default
+            payment platform is used and the address is assumed to be identical to
+            the Requestor's Node ID.
+
+
+            **NOTE:** The `makeDeposit` field is deprecated and ignored.
+          properties:
+            allocationId:
+              type: string
+              readOnly: true
+            spentAmount:
+              type: string
+              readOnly: true
+            remainingAmount:
+              type: string
+              readOnly: true
+            timestamp:
+              type: string
+              format: date-time
+              readOnly: true
+          required:
+            - allocationId
+            - spentAmount
+            - remainingAmount
+            - timestamp
 
     Payment:
       type: object

--- a/specs/payment-api.yaml
+++ b/specs/payment-api.yaml
@@ -1033,19 +1033,18 @@ components:
           agreementId:
             type: string
             readOnly: true
-
-      required:
-        - debitNoteId
-        - issuerId
-        - recipientId
-        - payeeAddr
-        - payerAddr
-        - paymentPlatform
-        - timestamp
-        - agreementId
-        - activityId
-        - totalAmountDue
-        - status
+        required:
+          - debitNoteId
+          - issuerId
+          - recipientId
+          - payeeAddr
+          - payerAddr
+          - paymentPlatform
+          - timestamp
+          - agreementId
+          - activityId
+          - totalAmountDue
+          - status
 
     Invoice:
       description: >

--- a/specs/payment-api.yaml
+++ b/specs/payment-api.yaml
@@ -1228,7 +1228,7 @@ components:
 
     Allocation:
       allOf:
-        - $ref: '#/components/schemas/Allocation'
+        - $ref: '#/components/schemas/AllocationWrite'
         - type: object
           description: >
             An Allocation is a designated sum of money reserved for the purpose of


### PR DESCRIPTION
* deprecate `makeDeposit` so that we can remove it at some point.
* split schemas using `required: true` for request/response distinction -- openapi-generator can't handle this properly.