### PR TITLE
Separate `Network` component into `Network` and `NewNetwork`

### DIFF
--- a/specs/net-api.yaml
+++ b/specs/net-api.yaml
@@ -37,7 +37,7 @@ paths:
       operationId: createNetwork
       summary: CreateNetwork - Creates a new Network.
       requestBody:
-        $ref: '#/components/requestBodies/Network'
+        $ref: '#/components/requestBodies/NewNetwork'
       responses:
         200:
           $ref: '#/components/responses/Network'
@@ -278,12 +278,12 @@ components:
           schema:
             $ref: '#/components/schemas/Address'
 
-    Network:
+    NewNetwork:
       required: true
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/Network'
+            $ref: '#/components/schemas/NewNetwork'
 
     Node:
       required: true
@@ -372,10 +372,25 @@ components:
           type: integer
           readOnly: true
 
-    Network:
+    NewNetwork:
       type: object
       required:
         - ip
+      properties:
+        ip:
+          type: string
+        mask:
+          type: string
+        gateway:
+          type: string
+
+    Network:
+      type: object
+      required:
+        - id
+        - ip
+        - mask
+        - gateway
       properties:
         id:
           type: string


### PR DESCRIPTION
The net api spec defines a network as:
```yaml
 Network:
    type: object
    required:
      - ip
    properties:
      id:
        type: string
      ip:
        type: string
      mask:
        type: string
      gateway:
        type: string
```
and claims that the `create-network` endpoint takes it as both the request body and return type. This is **not true**

1. The `id` parameter in request body is ignored, the new network always gets assigned a random id
2. The response is guaranteed to have all 4 properties defined

To fix this, I introduced a new component `NewNetwork` to match what's defined in [`model/src/net.rs`](https://github.com/golemfactory/ya-client/blob/master/model/src/net.rs#L19-L34):
```rust
pub struct Network {
    pub id: String,
    pub ip: String,
    pub mask: String,
    pub gateway: String,
}
pub struct NewNetwork {
    pub ip: String,
    pub mask: Option<String>,
    pub gateway: Option<String>,
}
```