### PR TITLE
Migrate to Diesel 2, Rust 2024, and mise

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,7 +11,6 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  rust_stable: 1.71.1
 
 jobs:
   build:
@@ -27,10 +26,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v1
 
-      - name: Install Rust ${{ env.rust_stable }}
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: ${{ env.rust_stable }}
+      - name: Set up mise
+        uses: jdx/mise-action@v4.2.5
 
       - name: Cache cargo registry
         uses: actions/cache@v4
@@ -55,25 +52,16 @@ jobs:
           key: ${{ runner.os }}-cargo-build-target1-${{ hashFiles('**/Cargo.lock') }}
 
       - name: cargo fmt
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+        run: mise x -- cargo fmt --all -- --check
 
       - name: cargo test
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --workspace
+        run: mise x -- cargo test --workspace
+
+      - name: cargo test with Diesel integration
+        run: mise x -- cargo test -p ya-client-model --features with-diesel
 
       - name: cargo test cli
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --features cli
+        run: mise x -- cargo test --features cli
 
       - name: cargo build
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --workspace
+        run: mise x -- cargo build --workspace

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["Golem Factory <contact@golem.network>"]
 homepage = "https://github.com/golemfactory/ya-client"
 repository = "https://github.com/golemfactory/ya-client"
 license = "LGPL-3.0"
-edition = "2021"
+edition = "2024"
 
 [features]
 default = []

--- a/examples/activity_interaction.rs
+++ b/examples/activity_interaction.rs
@@ -1,11 +1,10 @@
-use std::env;
 use std::time::Duration;
 
 use ya_client::{
+    Result,
     activity::{ActivityProviderApi, ActivityRequestorControlApi, ActivityRequestorStateApi},
     model::activity::ExeScriptRequest,
     web::WebClient,
-    Result,
 };
 
 async fn provider(client: &ActivityProviderApi, activity_id: &str) -> Result<()> {
@@ -82,14 +81,14 @@ async fn requestor_state(client: &ActivityRequestorStateApi, activity_id: &str) 
 async fn interact() -> Result<()> {
     let client = WebClient::builder().build();
     requestor(&client, "agreement_id").await?;
-    provider(&client.interface()?, "activity_id").await
+    let provider_client = client.interface()?;
+    provider(&provider_client, "activity_id").await
 }
 
 #[actix_rt::main]
 async fn main() -> Result<()> {
     println!("\nrun this example with RUST_LOG=info to see REST calls\n");
-    env::set_var("RUST_LOG", env::var("RUST_LOG").unwrap_or("warn".into()));
-    env_logger::init();
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("warn")).init();
 
     interact().await
 }

--- a/examples/allocation_management.rs
+++ b/examples/allocation_management.rs
@@ -1,13 +1,13 @@
-use std::{env, str::FromStr};
+use std::str::FromStr;
 
 use bigdecimal::BigDecimal;
 use chrono::{DateTime, Utc};
 use structopt::StructOpt;
 use url::Url;
 use ya_client::{
+    Result,
     payment::PaymentApi,
     web::{WebClient, WebInterface},
-    Result,
 };
 use ya_client_model::payment::allocation::PaymentPlatformEnum;
 use ya_client_model::payment::{Allocation, AllocationUpdate, NewAllocation};
@@ -59,11 +59,10 @@ fn print_allocations<'a>(allocations: impl IntoIterator<Item = &'a Allocation>) 
 async fn main() -> Result<()> {
     let options = Options::from_args();
     println!("\nrun this example with RUST_LOG=debug to see REST calls\n");
-    env::set_var(
-        "RUST_LOG",
-        env::var("RUST_LOG").unwrap_or(options.log_level.clone()),
-    );
-    env_logger::init();
+    env_logger::Builder::from_env(
+        env_logger::Env::default().default_filter_or(options.log_level.clone()),
+    )
+    .init();
 
     let client: PaymentApi = WebClient::with_token(&options.app_key).interface_at(options.url)?;
 

--- a/examples/market_interaction.rs
+++ b/examples/market_interaction.rs
@@ -1,16 +1,16 @@
-use std::{env, thread, time::Duration};
+use std::{thread, time::Duration};
 use structopt::StructOpt;
 use url::Url;
 
 use std::time::{SystemTime, UNIX_EPOCH};
 use ya_client::{
+    Error, Result,
     market::{MarketProviderApi, MarketRequestorApi},
     model::market::{
-        proposal::State, AgreementProposal, NewDemand, NewOffer, Proposal, ProviderEvent,
-        RequestorEvent,
+        AgreementProposal, NewDemand, NewOffer, Proposal, ProviderEvent, RequestorEvent,
+        proposal::State,
     },
     web::{WebClient, WebInterface},
-    Error, Result,
 };
 
 #[derive(Clone, StructOpt)]
@@ -295,11 +295,10 @@ async fn requestor_interact(options: Options, nanos: u32) -> Result<()> {
 async fn main() -> Result<()> {
     let options = Options::from_args();
     println!("\nrun this example with RUST_LOG=debug to see REST calls\n");
-    env::set_var(
-        "RUST_LOG",
-        env::var("RUST_LOG").unwrap_or(options.log_level.clone()),
-    );
-    env_logger::init();
+    env_logger::Builder::from_env(
+        env_logger::Env::default().default_filter_or(options.log_level.clone()),
+    )
+    .init();
 
     let nanos = SystemTime::now()
         .duration_since(UNIX_EPOCH)

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,2 @@
+[tools]
+rust = { version = "1.97.0", components = ["rustfmt", "clippy"], profile = "minimal" }

--- a/model/Cargo.toml
+++ b/model/Cargo.toml
@@ -6,11 +6,11 @@ authors = ["Golem Factory <contact@golem.network>"]
 homepage = "https://github.com/golemfactory/ya-client"
 repository = "https://github.com/golemfactory/ya-client"
 license = "LGPL-3.0"
-edition = "2021"
+edition = "2024"
 
 [features]
 default = []
-with-diesel = ['diesel']
+with-diesel = ['dep:diesel']
 sgx = ['secp256k1', 'openssl', 'hex', 'secp256k1/serde']
 
 [dependencies]
@@ -28,10 +28,13 @@ strum = "0.24.1"
 strum_macros = "0.24.3"
 thiserror = "1.0"
 
-diesel = { version = "1.4", optional = true }
+diesel = { version = "~2.1.0", optional = true }
 hex = { version = "0.4", optional = true }
 secp256k1 = { workspace = true, optional = true }
 openssl = { version = "0.10", optional = true }
+
+[dev-dependencies]
+diesel = { version = "~2.1.0", features = ["sqlite"] }
 
 [package.metadata.release]
 dev-version = false

--- a/model/Cargo.toml
+++ b/model/Cargo.toml
@@ -28,13 +28,13 @@ strum = "0.24.1"
 strum_macros = "0.24.3"
 thiserror = "1.0"
 
-diesel = { version = "~2.1.0", optional = true }
+diesel = { version = "2.1", optional = true }
 hex = { version = "0.4", optional = true }
 secp256k1 = { workspace = true, optional = true }
 openssl = { version = "0.10", optional = true }
 
 [dev-dependencies]
-diesel = { version = "~2.1.0", features = ["sqlite"] }
+diesel = { version = "2.1", features = ["sqlite"] }
 
 [package.metadata.release]
 dev-version = false

--- a/model/Cargo.toml
+++ b/model/Cargo.toml
@@ -35,6 +35,7 @@ openssl = { version = "0.10", optional = true }
 
 [dev-dependencies]
 diesel = { version = "2.1", features = ["sqlite"] }
+libsqlite3-sys = { version = "0.28", features = ["bundled"] }
 
 [package.metadata.release]
 dev-version = false

--- a/model/src/activity/encrypted.rs
+++ b/model/src/activity/encrypted.rs
@@ -86,7 +86,7 @@ impl EncryptionCtx {
 
     pub fn encrypt_bytes(&self, buf: &[u8]) -> Result<Vec<u8>, EncryptionError> {
         let mut bytes = Vec::with_capacity(12 + 16 + buf.len() + 5);
-        let iv: [u8; 12] = rand::thread_rng().gen();
+        let iv: [u8; 12] = rand::thread_rng().r#gen();
         let mut tag = [0u8; 16];
         let out = openssl::symm::encrypt_aead(
             openssl::symm::Cipher::aes_256_gcm(),

--- a/model/src/market/agreement.rs
+++ b/model/src/market/agreement.rs
@@ -11,8 +11,8 @@ use derive_more::Display;
 use serde::{Deserialize, Serialize};
 use strum_macros::EnumString;
 
-use crate::market::{Demand, Offer};
 use crate::NodeId;
+use crate::market::{Demand, Offer};
 
 /// Agreement expresses the terms of the deal between Provider and Requestor.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]

--- a/model/src/node_id.rs
+++ b/model/src/node_id.rs
@@ -1,4 +1,4 @@
-use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
+use serde::{Deserialize, Deserializer, Serialize, Serializer, de};
 use std::borrow::Cow;
 use std::convert::TryFrom;
 use std::str::FromStr;
@@ -29,6 +29,11 @@ pub struct InvalidLengthError {
 }
 
 /// Yagna node identity compliant with [Ethereum addresses](https://en.wikipedia.org/wiki/Ethereum#Addresses)
+#[cfg_attr(feature = "with-diesel", derive(diesel::FromSqlRow))]
+#[cfg_attr(
+    feature = "with-diesel",
+    diesel(sql_type = diesel::sql_types::Text)
+)]
 #[derive(Clone, Copy, Hash, PartialEq, Eq)]
 pub struct NodeId {
     inner: [u8; NODE_ID_LENGTH],
@@ -237,26 +242,23 @@ impl<'de> Deserialize<'de> for NodeId {
 mod sql {
     use super::NodeId;
     use diesel::backend::Backend;
-    use diesel::deserialize::FromSql;
-    use diesel::expression::bound::Bound;
+    use diesel::deserialize::{self, FromSql};
     use diesel::expression::AsExpression;
-    use diesel::serialize::{IsNull, Output, ToSql};
     use diesel::sql_types::Text;
-    use diesel::*;
 
     impl AsExpression<Text> for NodeId {
-        type Expression = Bound<Text, String>;
+        type Expression = <String as AsExpression<Text>>::Expression;
 
         fn as_expression(self) -> Self::Expression {
-            Bound::new(self.to_string())
+            <String as AsExpression<Text>>::as_expression(self.to_string())
         }
     }
 
     impl AsExpression<Text> for &NodeId {
-        type Expression = Bound<Text, String>;
+        type Expression = <String as AsExpression<Text>>::Expression;
 
         fn as_expression(self) -> Self::Expression {
-            Bound::new(self.to_string())
+            <String as AsExpression<Text>>::as_expression(self.to_string())
         }
     }
 
@@ -265,34 +267,31 @@ mod sql {
         DB: Backend,
         String: FromSql<Text, DB>,
     {
-        fn from_sql(bytes: Option<&<DB as Backend>::RawValue>) -> deserialize::Result<Self> {
+        fn from_sql(bytes: DB::RawValue<'_>) -> deserialize::Result<Self> {
             let s: String = FromSql::from_sql(bytes)?;
             Ok(s.parse()?)
         }
     }
-
-    impl<DB> ToSql<Text, DB> for NodeId
-    where
-        DB: Backend,
-        for<'b> &'b str: ToSql<Text, DB>,
-    {
-        fn to_sql<W: std::io::Write>(
-            &self,
-            out: &mut Output<'_, W, DB>,
-        ) -> deserialize::Result<IsNull> {
-            self.with_hex(move |s: &str| ToSql::<Text, DB>::to_sql(s, out))
-        }
-    }
-
-    #[derive(FromSqlRow)]
-    #[diesel(foreign_derive)]
-    struct NodeIdProxy(NodeId);
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use std::convert::TryInto;
+
+    #[cfg(feature = "with-diesel")]
+    diesel::table! {
+        diesel_node_ids (id) {
+            id -> Text,
+        }
+    }
+
+    #[cfg(feature = "with-diesel")]
+    #[derive(diesel::Insertable)]
+    #[diesel(table_name = diesel_node_ids)]
+    struct NewNodeId {
+        id: NodeId,
+    }
 
     #[test]
     fn parse_empty_str() {
@@ -353,6 +352,33 @@ mod tests {
                 .to_string(),
             "0xbabe000000000000000000000000000000000000".to_string()
         );
+    }
+
+    #[cfg(feature = "with-diesel")]
+    #[test]
+    fn diesel_sqlite_round_trip() {
+        use diesel::connection::SimpleConnection;
+        use diesel::{Connection, QueryDsl, RunQueryDsl, SqliteConnection};
+
+        let expected = "0xbabe000000000000000000000000000000000000"
+            .parse::<NodeId>()
+            .unwrap();
+        let mut connection = SqliteConnection::establish(":memory:").unwrap();
+        connection
+            .batch_execute("CREATE TABLE diesel_node_ids (id TEXT PRIMARY KEY NOT NULL)")
+            .unwrap();
+
+        diesel::insert_into(diesel_node_ids::table)
+            .values(NewNodeId { id: expected })
+            .execute(&mut connection)
+            .unwrap();
+
+        let actual = diesel_node_ids::table
+            .select(diesel_node_ids::id)
+            .first::<NodeId>(&mut connection)
+            .unwrap();
+
+        assert_eq!(actual, expected);
     }
 
     #[test]

--- a/model/src/payment/debit_note_event.rs
+++ b/model/src/payment/debit_note_event.rs
@@ -44,8 +44,8 @@ impl DebitNoteEventType {
     }
 
     pub fn details(&self) -> Option<serde_json::Value> {
-        use serde_json::to_value;
         use DebitNoteEventType::*;
+        use serde_json::to_value;
 
         match self {
             DebitNoteRejectedEvent { rejection } => to_value(rejection).ok(),
@@ -58,8 +58,8 @@ impl DebitNoteEventType {
         discriminant: &str,
         details: Option<serde_json::Value>,
     ) -> Option<Self> {
-        use serde_json::from_value;
         use DebitNoteEventType::*;
+        use serde_json::from_value;
 
         Some(match (discriminant, details) {
             ("RECEIVED", _) => DebitNoteReceivedEvent,

--- a/model/src/payment/invoice_event.rs
+++ b/model/src/payment/invoice_event.rs
@@ -44,8 +44,8 @@ impl InvoiceEventType {
     }
 
     pub fn details(&self) -> Option<serde_json::Value> {
-        use serde_json::to_value;
         use InvoiceEventType::*;
+        use serde_json::to_value;
 
         match self {
             InvoiceRejectedEvent { rejection } => to_value(rejection).ok(),
@@ -58,8 +58,8 @@ impl InvoiceEventType {
         discriminant: &str,
         details: Option<serde_json::Value>,
     ) -> Option<Self> {
-        use serde_json::from_value;
         use InvoiceEventType::*;
+        use serde_json::from_value;
 
         Some(match (discriminant, details) {
             ("RECEIVED", _) => InvoiceReceivedEvent,

--- a/model/src/payment/payment.rs
+++ b/model/src/payment/payment.rs
@@ -1,5 +1,5 @@
-use crate::payment::{ActivityPayment, AgreementPayment};
 use crate::NodeId;
+use crate::payment::{ActivityPayment, AgreementPayment};
 use bigdecimal::BigDecimal;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};

--- a/src/activity.rs
+++ b/src/activity.rs
@@ -3,9 +3,9 @@ mod provider;
 mod requestor;
 
 pub use provider::ActivityProviderApi;
+pub use requestor::ActivityRequestorApi;
 pub use requestor::control::ActivityRequestorControlApi;
 pub use requestor::state::ActivityRequestorStateApi;
-pub use requestor::ActivityRequestorApi;
 
 #[cfg(feature = "sgx")]
 pub use requestor::control::sgx::SecureActivityRequestorApi;

--- a/src/activity/provider.rs
+++ b/src/activity/provider.rs
@@ -1,7 +1,7 @@
 //! Provider part of the Activity API
-use ya_client_model::activity::{ActivityState, ActivityUsage, ProviderEvent, ACTIVITY_API_PATH};
+use ya_client_model::activity::{ACTIVITY_API_PATH, ActivityState, ActivityUsage, ProviderEvent};
 
-use crate::{web::default_on_timeout, web::WebClient, web::WebInterface, Result};
+use crate::{Result, web::WebClient, web::WebInterface, web::default_on_timeout};
 use chrono::{DateTime, Utc};
 use std::time::Duration;
 

--- a/src/activity/requestor.rs
+++ b/src/activity/requestor.rs
@@ -1,6 +1,6 @@
 //! Requestor part of the Activity API
-use crate::web::{WebClient, WebInterface};
 use crate::Result;
+use crate::web::{WebClient, WebInterface};
 use ya_client_model::activity::ACTIVITY_API_PATH;
 
 pub mod control;

--- a/src/activity/requestor/control.rs
+++ b/src/activity/requestor/control.rs
@@ -1,10 +1,10 @@
 //! Requestor control part of Activity API
 use ya_client_model::activity::{
-    CreateActivityRequest, CreateActivityResult, ExeScriptCommandResult, ExeScriptRequest,
-    RuntimeEvent, ACTIVITY_API_PATH,
+    ACTIVITY_API_PATH, CreateActivityRequest, CreateActivityResult, ExeScriptCommandResult,
+    ExeScriptRequest, RuntimeEvent,
 };
 
-use crate::web::{default_on_timeout, Event, WebClient, WebInterface};
+use crate::web::{Event, WebClient, WebInterface, default_on_timeout};
 use crate::{Error, Result};
 use futures::{Stream, StreamExt};
 use std::convert::TryFrom;
@@ -106,7 +106,7 @@ impl ActivityRequestorControlApi {
         &self,
         activity_id: &str,
         batch_id: &str,
-    ) -> Result<impl Stream<Item = RuntimeEvent>> {
+    ) -> Result<impl Stream<Item = RuntimeEvent> + use<>> {
         let uri = url_format!("activity/{activity_id}/exec/{batch_id}",);
         let stream = self
             .client
@@ -133,17 +133,17 @@ impl TryFrom<Event> for RuntimeEvent {
 #[cfg(feature = "sgx")]
 pub mod sgx {
     use super::*;
+    use crate::Error as AppError;
+    use crate::SGX_CONFIG;
     use crate::market::MarketRequestorApi;
     use crate::model::activity::encrypted as enc;
     use crate::model::activity::{Credentials, ExeScriptCommand, SgxCredentials};
-    use crate::Error as AppError;
-    use crate::SGX_CONFIG;
     use graphene_sgx::AttestationResponse;
     use hex;
     use secp256k1::{PublicKey, SecretKey};
     use std::sync::Arc;
-    use ya_client_model::activity::encrypted::EncryptionCtx;
     use ya_client_model::activity::ExeScriptCommandState;
+    use ya_client_model::activity::encrypted::EncryptionCtx;
 
     #[derive(thiserror::Error, Debug)]
     pub enum SgxError {
@@ -197,7 +197,7 @@ pub mod sgx {
 
     fn gen_id() -> String {
         use rand::Rng;
-        let v: u128 = rand::thread_rng().gen();
+        let v: u128 = rand::thread_rng().r#gen();
         format!("{:032x}", v)
     }
 
@@ -376,7 +376,7 @@ mod test {
 
         let ctx1 = EncryptionCtx::new(&p2, &s1);
         let ctx2 = EncryptionCtx::new(&p1, &s2);
-        let data: [u8; 20] = rng.gen();
+        let data: [u8; 20] = rng.r#gen();
         let data2 = ctx2
             .decrypt_bytes(&ctx1.encrypt_bytes(&data).unwrap())
             .unwrap();

--- a/src/activity/requestor/state.rs
+++ b/src/activity/requestor/state.rs
@@ -1,9 +1,9 @@
 //! Requestor state part of Activity API
 use ya_client_model::activity::{
-    ActivityState, ActivityUsage, ExeScriptCommandState, ACTIVITY_API_PATH,
+    ACTIVITY_API_PATH, ActivityState, ActivityUsage, ExeScriptCommandState,
 };
 
-use crate::{web::WebClient, web::WebInterface, Result};
+use crate::{Result, web::WebClient, web::WebInterface};
 
 /// Bindings for Requestor State part of the Activity API.
 #[derive(Clone)]

--- a/src/identity.rs
+++ b/src/identity.rs
@@ -1,7 +1,7 @@
 use ya_client_model::identity::Identity;
 
-use crate::web::{WebClient, WebInterface};
 use crate::Result;
+use crate::web::{WebClient, WebInterface};
 
 pub const IDENTITY_URL_ENV_VAR: &str = "YAGNA_IDENTITY_URL";
 

--- a/src/market/provider.rs
+++ b/src/market/provider.rs
@@ -1,11 +1,11 @@
 //! Provider part of the Market API
 use ya_client_model::market::{
-    agreement::State, Agreement, AgreementListEntry, AgreementOperationEvent,
-    AgreementTerminationReason, NewOffer, NewProposal, Offer, Proposal, ProviderEvent, Reason,
-    MARKET_API_PATH,
+    Agreement, AgreementListEntry, AgreementOperationEvent, AgreementTerminationReason,
+    MARKET_API_PATH, NewOffer, NewProposal, Offer, Proposal, ProviderEvent, Reason,
+    agreement::State,
 };
 
-use crate::{web::default_on_timeout, web::WebClient, web::WebInterface, Result};
+use crate::{Result, web::WebClient, web::WebInterface, web::default_on_timeout};
 use chrono::{DateTime, TimeZone, Utc};
 use std::fmt::Display;
 

--- a/src/market/requestor.rs
+++ b/src/market/requestor.rs
@@ -1,15 +1,15 @@
 //! Requestor part of the Market API
 use ya_client_model::market::{
-    agreement::State, Agreement, AgreementListEntry, AgreementOperationEvent, AgreementProposal,
+    Agreement, AgreementListEntry, AgreementOperationEvent, AgreementProposal,
     AgreementTerminationReason, Demand, NewDemand, NewProposal, Offer, Proposal, Reason,
-    RequestorEvent,
+    RequestorEvent, agreement::State,
 };
 
-use crate::{web::default_on_timeout, web::WebClient, web::WebInterface, Result};
+use crate::{Result, web::WebClient, web::WebInterface, web::default_on_timeout};
 use chrono::{DateTime, TimeZone, Utc};
 use std::fmt::Display;
-use ya_client_model::market::scan::NewScan;
 use ya_client_model::NodeId;
+use ya_client_model::market::scan::NewScan;
 
 /// Bindings for Requestor part of the Market API.
 #[derive(Clone)]

--- a/src/net.rs
+++ b/src/net.rs
@@ -2,9 +2,9 @@ use crate::error::Error;
 use crate::model::net::*;
 use crate::web::{WebClient, WebInterface};
 use actix_codec::Framed;
+use awc::BoxedSocket;
 use awc::http::Method;
 use awc::ws::Codec;
-use awc::BoxedSocket;
 use std::ops::Not;
 
 pub const NET_URL_ENV_VAR: &str = "YAGNA_NET_URL";

--- a/src/payment/api.rs
+++ b/src/payment/api.rs
@@ -6,8 +6,8 @@ use std::marker::PhantomData;
 use std::sync::Arc;
 
 use crate::{
-    web::{default_on_timeout, url_format_obj, WebClient, WebInterface},
     Result,
+    web::{WebClient, WebInterface, default_on_timeout, url_format_obj},
 };
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
@@ -216,7 +216,7 @@ impl PaymentApi {
     ///     }
     /// }
     /// ```
-    pub fn events<Evtype: PaymentEvent>(&self) -> EventsBuilder<Evtype> {
+    pub fn events<Evtype: PaymentEvent>(&self) -> EventsBuilder<'_, Evtype> {
         EventsBuilder::with_client(&self.client)
     }
 
@@ -565,11 +565,7 @@ impl<'a, EvType: PaymentEvent> EventsBuilder<'a, EvType> {
             }
             buf.push_str(&ename)
         }
-        if buf.is_empty() {
-            None
-        } else {
-            Some(buf)
-        }
+        if buf.is_empty() { None } else { Some(buf) }
     }
 
     pub fn provider_events(

--- a/src/web.rs
+++ b/src/web.rs
@@ -1,24 +1,24 @@
 //! Web utils
 use actix_codec::Framed;
 use awc::{
+    BoxedSocket, ClientRequest, ClientResponse, SendClientRequest,
     error::{PayloadError, SendRequestError},
     http::header::{HeaderMap, HeaderName, HeaderValue},
-    http::{header, Method, StatusCode},
+    http::{Method, StatusCode, header},
     ws::Codec,
-    BoxedSocket, ClientRequest, ClientResponse, SendClientRequest,
 };
 use bytes::{Bytes, BytesMut};
 use futures::stream::Peekable;
 use futures::{Stream, StreamExt, TryStreamExt};
 use heck::ToLowerCamelCase;
-use serde::{de::DeserializeOwned, Serialize};
+use serde::{Serialize, de::DeserializeOwned};
 use serde_qs;
 use std::cmp::max;
 use std::convert::TryFrom;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 use std::{env, rc::Rc, str::FromStr, time::Duration};
-use url::{form_urlencoded, Url};
+use url::{Url, form_urlencoded};
 
 use crate::model::ErrorMessage;
 use crate::{Error, Result};
@@ -118,7 +118,10 @@ impl WebClient {
         }
     }
 
-    pub async fn event_stream(&self, url: &str) -> Result<impl Stream<Item = Result<Event>>> {
+    pub async fn event_stream(
+        &self,
+        url: &str,
+    ) -> Result<impl Stream<Item = Result<Event>> + use<>> {
         let url = self.url(url).unwrap().to_string();
         log::debug!("event stream at {}", url);
         let method = Method::GET;
@@ -505,13 +508,14 @@ where
                 let idx = this.buffer.len();
                 this.buffer.extend(bytes);
 
-                if let Some(result) = this.next_event(idx) {
-                    Poll::Ready(Some(result))
-                } else {
-                    if Pin::new(&mut this.inner).poll_peek(cx).is_ready() {
-                        cx.waker().wake_by_ref();
+                match this.next_event(idx) {
+                    Some(result) => Poll::Ready(Some(result)),
+                    _ => {
+                        if Pin::new(&mut this.inner).poll_peek(cx).is_ready() {
+                            cx.waker().wake_by_ref();
+                        }
+                        Poll::Pending
                     }
-                    Poll::Pending
                 }
             }
             Poll::Ready(Some(Err(e))) => Poll::Ready(Some(Err(e.into()))),
@@ -533,7 +537,7 @@ where
 /// url_format!("foo", #[query] bar) => "foo?bar=" + bar
 macro_rules! url_format {
     {
-        $path:expr $(,$var:ident)* $(,#[query] $varq:ident)* $(,)?
+        $path:expr_2021 $(,$var:ident)* $(,#[query] $varq:ident)* $(,)?
     } => {{
         let mut url = format!( $path $(, $var)* );
         let query = crate::web::QueryParamsBuilder::default()


### PR DESCRIPTION
## Summary

- migrate `ya-client-model` from Diesel 1.4 to `>=2.1,<3` (currently resolves to Diesel 2.3.12)
- update `NodeId` SQL conversions to Diesel 2 APIs and add an SQLite round-trip test
- migrate both crates to Rust edition 2024
- define Rust 1.97.0 with rustfmt and clippy in `mise.toml`
- replace actions-rs CI steps with `jdx/mise-action` and `mise x -- cargo ...`

## Validation

- `mise x -- cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings -C opt-level=z -C target-cpu=native -C debuginfo=1" mise x -- cargo test --workspace`
- `RUSTFLAGS="-D warnings -C opt-level=z -C target-cpu=native -C debuginfo=1" mise x -- cargo test -p ya-client-model --features with-diesel` (Diesel 2.1.6 and 2.3.12)
- `RUSTFLAGS="-D warnings -C opt-level=z -C target-cpu=native -C debuginfo=1" mise x -- cargo test --features cli`
- `RUSTFLAGS="-D warnings -C opt-level=z -C target-cpu=native -C debuginfo=1" mise x -- cargo build --workspace`